### PR TITLE
feat(bridge): harden network tunnel adapter (F1-F7) + bump 0.3.0

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -12,68 +12,61 @@ the project adheres to
 
 ### Added
 
-- **New submodule `@casys/mcp-bridge/adapters/network`.** Outbound
-  WebSocket tunnel primitives: agents inside a customer LAN dial a
-  SaaS relay and serve `tool.call` over the resulting socket. Three
-  pieces: `NetworkRelay` (server-side registry + routing),
-  `NetworkTunnelClient` (agent-side handler with reconnect loop) and
-  `WebSocketNetworkTransport` (concrete WS transport supporting
-  bearer header / custom headers; query bearer accepted at the bridge
+- **New submodule `@casys/mcp-bridge/adapters/network`.** Outbound WebSocket
+  tunnel primitives: agents inside a customer LAN dial a SaaS relay and serve
+  `tool.call` over the resulting socket. Three pieces: `NetworkRelay`
+  (server-side registry + routing), `NetworkTunnelClient` (agent-side handler
+  with reconnect loop) and `WebSocketNetworkTransport` (concrete WS transport
+  supporting bearer header / custom headers; query bearer accepted at the bridge
   but redacted from all error output, see below).
 - **`NETWORK_PROTOCOL_VERSION = 1` constant** on the wire contract.
-  `agent.hello` and `agent.ready` frames carry `protocolVersion`;
-  mismatched or missing values close with WS code 4002 "protocol
-  version mismatch". Lets future incompatible changes be rejected
-  deterministically.
-- **`NetworkRelayError` class** with `code`/`context`/`recovery`
-  fields (AX #4 — structured machine-readable errors). Five codes:
-  `NO_TUNNEL_AGENT`, `TUNNEL_AGENT_BUSY`, `TUNNEL_AGENT_DISCONNECTED`,
-  `TUNNEL_REQUEST_CANCELLED`, `TUNNEL_REQUEST_TIMEOUT`. Replaces the
-  previous plain `Error("CODE message")` strings that callers had to
-  grep on.
-- **Per-agent `AbortSignal` end-to-end.** `RegisteredNetworkAgent.send`
-  now accepts `{ signal }`; on relay timeout the controller aborts and
-  a cancellation frame is sent over the socket so the local agent can
-  drop its in-flight work. The agent slot stays "busy" until the send
-  path actually settles, so a timed-out call cannot leak a concurrent
-  slot.
-- **`NetworkTunnelReconnectOptions`** on `NetworkTunnelClient`.
-  Bounded exponential backoff (default initial 1s, cap 60s, ±20%
-  jitter), re-hello on each connect. Terminal close codes (4001 auth /
-  4002 protocol / 4004 no config / 4009 wrong mode) stop the loop and
-  surface a structured error via `onTerminalError`. Recoverable codes
-  (1006-style) retry.
+  `agent.hello` and `agent.ready` frames carry `protocolVersion`; mismatched or
+  missing values close with WS code 4002 "protocol version mismatch". Lets
+  future incompatible changes be rejected deterministically.
+- **`NetworkRelayError` class** with `code`/`context`/`recovery` fields (AX #4 —
+  structured machine-readable errors). Five codes: `NO_TUNNEL_AGENT`,
+  `TUNNEL_AGENT_BUSY`, `TUNNEL_AGENT_DISCONNECTED`, `TUNNEL_REQUEST_CANCELLED`,
+  `TUNNEL_REQUEST_TIMEOUT`. Replaces the previous plain `Error("CODE message")`
+  strings that callers had to grep on.
+- **Per-agent `AbortSignal` end-to-end.** `RegisteredNetworkAgent.send` now
+  accepts `{ signal }`; on relay timeout the controller aborts and a
+  cancellation frame is sent over the socket so the local agent can drop its
+  in-flight work. The agent slot stays "busy" until the send path actually
+  settles, so a timed-out call cannot leak a concurrent slot.
+- **`NetworkTunnelReconnectOptions`** on `NetworkTunnelClient`. Bounded
+  exponential backoff (default initial 1s, cap 60s, ±20% jitter), re-hello on
+  each connect. Terminal close codes (4001 auth / 4002 protocol / 4004 no config
+  / 4009 wrong mode) stop the loop and surface a structured error via
+  `onTerminalError`. Recoverable codes (1006-style) retry.
 
 ### Changed
 
 - **`NetworkRelay` default `concurrencyStrategy` is now `"reject"`**
-  (one-call-at-a-time per agent). The previous default was `"parallel"`
-  which a review surfaced as unsafe — a slow handler could leak
-  concurrent slots and break the relay's per-agent isolation
-  guarantee. Callers that need parallel mode must opt in explicitly
-  via `concurrencyStrategy: "parallel"`. **This is a breaking change
-  for consumers that relied on the parallel default; valid under
+  (one-call-at-a-time per agent). The previous default was `"parallel"` which a
+  review surfaced as unsafe — a slow handler could leak concurrent slots and
+  break the relay's per-agent isolation guarantee. Callers that need parallel
+  mode must opt in explicitly via `concurrencyStrategy: "parallel"`. **This is a
+  breaking change for consumers that relied on the parallel default; valid under
   pre-1.0 semver.**
 - **Pending in-flight calls are now rejected on socket close AND on
-  `unregisterAgent`.** Previously a close mid-call left the awaiting
-  caller hanging on a never-resolving promise. Now both paths reject
-  with structured `TUNNEL_AGENT_DISCONNECTED` / `TUNNEL_REQUEST_CANCELLED`.
-- **Test-only `allowInsecureNetworkAgentHelloForTests` helper** moved
-  from the public exports (`adapters/network/mod.ts` and root
-  `src/mod.ts`) into a non-published `_test-fixtures.ts` fixture file.
-  Production consumers could previously build a relay that accepted
-  any `agent.hello` — that surface is removed.
+  `unregisterAgent`.** Previously a close mid-call left the awaiting caller
+  hanging on a never-resolving promise. Now both paths reject with structured
+  `TUNNEL_AGENT_DISCONNECTED` / `TUNNEL_REQUEST_CANCELLED`.
+- **Test-only `allowInsecureNetworkAgentHelloForTests` helper** moved from the
+  public exports (`adapters/network/mod.ts` and root `src/mod.ts`) into a
+  non-published `_test-fixtures.ts` fixture file. Production consumers could
+  previously build a relay that accepted any `agent.hello` — that surface is
+  removed.
 
 ### Security
 
-- **Query bearer tokens are now redacted from WS error strings.** The
-  transport supports `auth.via: "query"` for environments where headers
-  can't be injected; when this fails (connect refused, close before
-  open) the URL — including any `access_token`/`token` parameter — was
-  previously interpolated into the error message and propagated to
-  caller logs. A new `redactUrl(url, queryParam?)` helper replaces
-  bearer values with `***` before interpolation. Default-strip set:
-  `access_token`, `token`; consumers can pass a custom `queryParam`.
+- **Query bearer tokens are now redacted from WS error strings.** The transport
+  supports `auth.via: "query"` for environments where headers can't be injected;
+  when this fails (connect refused, close before open) the URL — including any
+  `access_token`/`token` parameter — was previously interpolated into the error
+  message and propagated to caller logs. A new `redactUrl(url, queryParam?)`
+  helper replaces bearer values with `***` before interpolation. Default-strip
+  set: `access_token`, `token`; consumers can pass a custom `queryParam`.
 
 ### Fixed
 
@@ -85,19 +78,17 @@ the project adheres to
 
 ### Migration notes
 
-- Consumers that explicitly relied on `concurrencyStrategy: "parallel"`
-  being the default must add it to their `NetworkRelay` options now.
-  Recommended: keep the new `"reject"` default; only opt back into
-  parallel if you have specific reason (and document it).
-- Consumers that imported `allowInsecureNetworkAgentHelloForTests`
-  from `@casys/mcp-bridge` or `@casys/mcp-bridge/adapters/network`
-  must import the helper directly from
-  `@casys/mcp-bridge/adapters/network/_test-fixtures.ts` (test-only;
-  not part of the public API surface).
+- Consumers that explicitly relied on `concurrencyStrategy: "parallel"` being
+  the default must add it to their `NetworkRelay` options now. Recommended: keep
+  the new `"reject"` default; only opt back into parallel if you have specific
+  reason (and document it).
+- Consumers that imported `allowInsecureNetworkAgentHelloForTests` from
+  `@casys/mcp-bridge` or `@casys/mcp-bridge/adapters/network` must import the
+  helper directly from `@casys/mcp-bridge/adapters/network/_test-fixtures.ts`
+  (test-only; not part of the public API surface).
 - The new `protocolVersion` field is REQUIRED on `agent.hello` and
-  `agent.ready`. The bundled `NetworkTunnelClient` sets it
-  automatically; custom clients must set it to
-  `NETWORK_PROTOCOL_VERSION`.
+  `agent.ready`. The bundled `NetworkTunnelClient` sets it automatically; custom
+  clients must set it to `NETWORK_PROTOCOL_VERSION`.
 
 ## [0.2.0] - 2026-03-XX
 

--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -8,6 +8,73 @@ the project adheres to
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-19
+
+### Added
+
+- **New submodule `@casys/mcp-bridge/adapters/network`.** Outbound
+  WebSocket tunnel primitives: agents inside a customer LAN dial a
+  SaaS relay and serve `tool.call` over the resulting socket. Three
+  pieces: `NetworkRelay` (server-side registry + routing),
+  `NetworkTunnelClient` (agent-side handler with reconnect loop) and
+  `WebSocketNetworkTransport` (concrete WS transport supporting
+  bearer header / custom headers; query bearer accepted at the bridge
+  but redacted from all error output, see below).
+- **`NETWORK_PROTOCOL_VERSION = 1` constant** on the wire contract.
+  `agent.hello` and `agent.ready` frames carry `protocolVersion`;
+  mismatched or missing values close with WS code 4002 "protocol
+  version mismatch". Lets future incompatible changes be rejected
+  deterministically.
+- **`NetworkRelayError` class** with `code`/`context`/`recovery`
+  fields (AX #4 — structured machine-readable errors). Five codes:
+  `NO_TUNNEL_AGENT`, `TUNNEL_AGENT_BUSY`, `TUNNEL_AGENT_DISCONNECTED`,
+  `TUNNEL_REQUEST_CANCELLED`, `TUNNEL_REQUEST_TIMEOUT`. Replaces the
+  previous plain `Error("CODE message")` strings that callers had to
+  grep on.
+- **Per-agent `AbortSignal` end-to-end.** `RegisteredNetworkAgent.send`
+  now accepts `{ signal }`; on relay timeout the controller aborts and
+  a cancellation frame is sent over the socket so the local agent can
+  drop its in-flight work. The agent slot stays "busy" until the send
+  path actually settles, so a timed-out call cannot leak a concurrent
+  slot.
+- **`NetworkTunnelReconnectOptions`** on `NetworkTunnelClient`.
+  Bounded exponential backoff (default initial 1s, cap 60s, ±20%
+  jitter), re-hello on each connect. Terminal close codes (4001 auth /
+  4002 protocol / 4004 no config / 4009 wrong mode) stop the loop and
+  surface a structured error via `onTerminalError`. Recoverable codes
+  (1006-style) retry.
+
+### Changed
+
+- **`NetworkRelay` default `concurrencyStrategy` is now `"reject"`**
+  (one-call-at-a-time per agent). The previous default was `"parallel"`
+  which a review surfaced as unsafe — a slow handler could leak
+  concurrent slots and break the relay's per-agent isolation
+  guarantee. Callers that need parallel mode must opt in explicitly
+  via `concurrencyStrategy: "parallel"`. **This is a breaking change
+  for consumers that relied on the parallel default; valid under
+  pre-1.0 semver.**
+- **Pending in-flight calls are now rejected on socket close AND on
+  `unregisterAgent`.** Previously a close mid-call left the awaiting
+  caller hanging on a never-resolving promise. Now both paths reject
+  with structured `TUNNEL_AGENT_DISCONNECTED` / `TUNNEL_REQUEST_CANCELLED`.
+- **Test-only `allowInsecureNetworkAgentHelloForTests` helper** moved
+  from the public exports (`adapters/network/mod.ts` and root
+  `src/mod.ts`) into a non-published `_test-fixtures.ts` fixture file.
+  Production consumers could previously build a relay that accepted
+  any `agent.hello` — that surface is removed.
+
+### Security
+
+- **Query bearer tokens are now redacted from WS error strings.** The
+  transport supports `auth.via: "query"` for environments where headers
+  can't be injected; when this fails (connect refused, close before
+  open) the URL — including any `access_token`/`token` parameter — was
+  previously interpolated into the error message and propagated to
+  caller logs. A new `redactUrl(url, queryParam?)` helper replaces
+  bearer values with `***` before interpolation. Default-strip set:
+  `access_token`, `token`; consumers can pass a custom `queryParam`.
+
 ### Fixed
 
 - **`scripts/build-npm.ts` no longer hardcodes the package version.** The script
@@ -15,6 +82,22 @@ the project adheres to
   same pattern as `packages/compose/scripts/build-npm.ts`). Previously every npm
   publish would have shipped `0.2.0` regardless of the value in `deno.json`.
   Pure build-time fix; no runtime impact.
+
+### Migration notes
+
+- Consumers that explicitly relied on `concurrencyStrategy: "parallel"`
+  being the default must add it to their `NetworkRelay` options now.
+  Recommended: keep the new `"reject"` default; only opt back into
+  parallel if you have specific reason (and document it).
+- Consumers that imported `allowInsecureNetworkAgentHelloForTests`
+  from `@casys/mcp-bridge` or `@casys/mcp-bridge/adapters/network`
+  must import the helper directly from
+  `@casys/mcp-bridge/adapters/network/_test-fixtures.ts` (test-only;
+  not part of the public API surface).
+- The new `protocolVersion` field is REQUIRED on `agent.hello` and
+  `agent.ready`. The bundled `NetworkTunnelClient` sets it
+  automatically; custom clients must set it to
+  `NETWORK_PROTOCOL_VERSION`.
 
 ## [0.2.0] - 2026-03-XX
 

--- a/packages/bridge/deno.json
+++ b/packages/bridge/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-bridge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/bridge/deno.json
+++ b/packages/bridge/deno.json
@@ -2,7 +2,10 @@
   "name": "@casys/mcp-bridge",
   "version": "0.2.0",
   "license": "MIT",
-  "exports": "./src/mod.ts",
+  "exports": {
+    ".": "./src/mod.ts",
+    "./adapters/network": "./src/adapters/network/mod.ts"
+  },
   "publish": {
     "include": [
       "src/**/*.ts",
@@ -17,7 +20,7 @@
     ]
   },
   "tasks": {
-    "test": "deno test --allow-net --allow-read tests/",
+    "test": "deno test --allow-net --allow-read src/ tests/",
     "check": "deno check src/mod.ts",
     "lint": "deno lint",
     "build:npm": "deno run -A scripts/build-npm.ts",

--- a/packages/bridge/docs/decision-records/0001-network-tunnel-scope.md
+++ b/packages/bridge/docs/decision-records/0001-network-tunnel-scope.md
@@ -1,28 +1,25 @@
 # ADR 0001: Network tunnel primitives belong in mcp-bridge
 
-Date: 2026-05-09  Status: Accepted
+Date: 2026-05-09 Status: Accepted
 
 ## Context
 
-Until now, `@casys/mcp-bridge` has been positioned as a **UI bridge** —
-it serves MCP Apps `ui://` resources inside hosts that don't render
-them natively (Telegram Mini Apps, LINE LIFF). The README, the package
-description, and the directory layout (`adapters/telegram/`,
-`adapters/line/`) reinforce this scope.
+Until now, `@casys/mcp-bridge` has been positioned as a **UI bridge** — it
+serves MCP Apps `ui://` resources inside hosts that don't render them natively
+(Telegram Mini Apps, LINE LIFF). The README, the package description, and the
+directory layout (`adapters/telegram/`, `adapters/line/`) reinforce this scope.
 
-Independently, `@casys/mcp-compose/src/deploy/` ships a **design
-document** (readme + contract + types, no impl) for publishing dashboards
-on Deno Deploy, which includes a **WebSocket tunnel** for local-data
-MCPs:
+Independently, `@casys/mcp-compose/src/deploy/` ships a **design document**
+(readme + contract + types, no impl) for publishing dashboards on Deno Deploy,
+which includes a **WebSocket tunnel** for local-data MCPs:
 
-> *"Local-data MCPs (DB, Docker, local files) → SDK starts MCP locally
-> → SDK opens outbound WebSocket to relay → Relay routes tool calls
-> through tunnel."*
+> _"Local-data MCPs (DB, Docker, local files) → SDK starts MCP locally → SDK
+> opens outbound WebSocket to relay → Relay routes tool calls through tunnel."_
 
-A new, unrelated project (`erp-platform`, a multi-tenant SaaS that talks
-to ERPNext/Dolibarr instances running **on the customer's premises**)
-needs the same primitive: an outbound WebSocket from a local agent to
-a SaaS relay, routing MCP `tools/call` through the tunnel.
+A new, unrelated project (`erp-platform`, a multi-tenant SaaS that talks to
+ERPNext/Dolibarr instances running **on the customer's premises**) needs the
+same primitive: an outbound WebSocket from a local agent to a SaaS relay,
+routing MCP `tools/call` through the tunnel.
 
 The question: where does this **network tunnel** primitive belong?
 
@@ -32,72 +29,67 @@ The question: where does this **network tunnel** primitive belong?
 
 Pros: strict SRP, decouples "tunnel" from "UI bridging" packaging.
 
-Cons: **duplicates ~1600 LOC of WebSocket + JSON-RPC + session/router
-plumbing already living in `mcp-bridge/src/core/`** (battle-tested,
-~120 tests). Two packages would each carry their own copy of the same
-machinery.
+Cons: **duplicates ~1600 LOC of WebSocket + JSON-RPC + session/router plumbing
+already living in `mcp-bridge/src/core/`** (battle-tested, ~120 tests). Two
+packages would each carry their own copy of the same machinery.
 
 ### B. Inside `@casys/mcp-compose/src/deploy/`
 
 Pros: design already there, types defined.
 
-Cons: `mcp-compose` is a **dashboard composition** library. The tunnel
-is a primitive used by `compose/deploy` for one specific use case
-(publishing a composed dashboard with local-data MCPs), but the
-primitive itself is more general. Locking it inside `compose/deploy/`
-means every other consumer (erp-platform, future on-prem cases) would
-have to import all of `mcp-compose` to reach it.
+Cons: `mcp-compose` is a **dashboard composition** library. The tunnel is a
+primitive used by `compose/deploy` for one specific use case (publishing a
+composed dashboard with local-data MCPs), but the primitive itself is more
+general. Locking it inside `compose/deploy/` means every other consumer
+(erp-platform, future on-prem cases) would have to import all of `mcp-compose`
+to reach it.
 
 ### C. Inside `@casys/mcp-server` core
 
 Pros: it's a transport-level concern.
 
 Cons: the tunnel has two sides (relay server + local agent), with
-auth/session/routing surface. That's more than a transport — it's a
-mini-product on top of the transport.
+auth/session/routing surface. That's more than a transport — it's a mini-product
+on top of the transport.
 
 ### D. Inside `@casys/mcp-bridge`, as a new `adapters/network/` sibling
 
 Pros:
 
-- **Semantic correctness**: `bridge` literally means "passing traffic
-  between two environments that can't talk directly". Telegram bridge,
-  LINE bridge, on-prem bridge are three instances of the same concept.
-  The current package name is a *generic* bridging concept; the
-  Telegram/LINE specialization is just what shipped first.
-- **Code reuse**: `bridge/src/core/` already implements the exact
-  primitives a network tunnel needs (WebSocket transport, JSON-RPC
-  protocol builders, MessageRouter, session abstraction with auth
-  handler, BridgeClient). Targeted reuse, no duplication.
-- **Modular extension**: `adapters/network/` sits next to
-  `adapters/telegram/`, `adapters/line/`. Same shape, same pattern.
-  Adding more bridging adapters (Slack, Discord, IRC, custom RPC) does
-  not destabilize the package.
+- **Semantic correctness**: `bridge` literally means "passing traffic between
+  two environments that can't talk directly". Telegram bridge, LINE bridge,
+  on-prem bridge are three instances of the same concept. The current package
+  name is a _generic_ bridging concept; the Telegram/LINE specialization is just
+  what shipped first.
+- **Code reuse**: `bridge/src/core/` already implements the exact primitives a
+  network tunnel needs (WebSocket transport, JSON-RPC protocol builders,
+  MessageRouter, session abstraction with auth handler, BridgeClient). Targeted
+  reuse, no duplication.
+- **Modular extension**: `adapters/network/` sits next to `adapters/telegram/`,
+  `adapters/line/`. Same shape, same pattern. Adding more bridging adapters
+  (Slack, Discord, IRC, custom RPC) does not destabilize the package.
 
 Cons:
 
-- The `mcp-bridge` external positioning has to evolve from "UI bridging"
-  to "MCP bridging (UI **and** network)". This is a documentation /
-  README change, not an architectural one.
-- Some users that import `mcp-bridge` expecting only Telegram/LINE
-  surface might be surprised by the network-tunnel exports — but
-  exports are tree-shakeable, so there is no runtime cost.
+- The `mcp-bridge` external positioning has to evolve from "UI bridging" to "MCP
+  bridging (UI **and** network)". This is a documentation / README change, not
+  an architectural one.
+- Some users that import `mcp-bridge` expecting only Telegram/LINE surface might
+  be surprised by the network-tunnel exports — but exports are tree-shakeable,
+  so there is no runtime cost.
 
 ## Decision
 
-**D — `@casys/mcp-bridge`, with a new `src/adapters/network/`
-sub-module.**
+**D — `@casys/mcp-bridge`, with a new `src/adapters/network/` sub-module.**
 
-The `core/` primitives (WebSocketTransport, MessageRouter, protocol
-builders, BridgeSession, auth handler) are reused as-is. The network
-adapter sits next to `adapters/telegram/` and `adapters/line/` and ships
-its own client (run by the customer-side agent) and server (run by the
-SaaS relay).
+The `core/` primitives (WebSocketTransport, MessageRouter, protocol builders,
+BridgeSession, auth handler) are reused as-is. The network adapter sits next to
+`adapters/telegram/` and `adapters/line/` and ships its own client (run by the
+customer-side agent) and server (run by the SaaS relay).
 
-The package description / README will evolve to describe `mcp-bridge`
-as a generic bridging layer, with sub-modules per host platform — the
-host being either a messaging app (Telegram/LINE) or a network endpoint
-(SaaS relay).
+The package description / README will evolve to describe `mcp-bridge` as a
+generic bridging layer, with sub-modules per host platform — the host being
+either a messaging app (Telegram/LINE) or a network endpoint (SaaS relay).
 
 ## Consequences
 
@@ -105,57 +97,53 @@ host being either a messaging app (Telegram/LINE) or a network endpoint
 
 The tunnel types (`TunnelConnection`, `DeployTransport`) currently in
 `mcp-compose/src/deploy/types.ts` are **structurally relocated** to
-`mcp-bridge/src/adapters/network/types.ts`. `mcp-compose/deploy/`
-imports them from there, and the deploy module narrows its
-responsibility to:
+`mcp-bridge/src/adapters/network/types.ts`. `mcp-compose/deploy/` imports them
+from there, and the deploy module narrows its responsibility to:
 
-- the Deno Deploy publishing logic (creating relay project, deploying
-  cloud-side MCPs)
+- the Deno Deploy publishing logic (creating relay project, deploying cloud-side
+  MCPs)
 - the dashboard-specific HTML wiring
 
-The "tunnel" is no longer something `mcp-compose` *owns*. It's
-something it *uses*.
+The "tunnel" is no longer something `mcp-compose` _owns_. It's something it
+_uses_.
 
 ### Action items (deferred, separate sessions)
 
-- Implement `mcp-bridge/src/adapters/network/{client,server,auth,types}.ts`
-  with first-class support for: outbound WS from local agent, multi-tenant
-  routing on relay side, agent registration handshake, secret rotation,
-  reconnect, backpressure, replay/idempotence on `tools/call`.
-- Migrate types from `mcp-compose/src/deploy/types.ts` (the bits that
-  describe the tunnel, **not** the deploy-specific request/result).
-- Update `mcp-compose/src/deploy/readme.md` and `contract.md` to point
-  at `@casys/mcp-bridge`'s network adapter instead of describing the
-  tunnel inline.
+- Implement `mcp-bridge/src/adapters/network/{client,server,auth,types}.ts` with
+  first-class support for: outbound WS from local agent, multi-tenant routing on
+  relay side, agent registration handshake, secret rotation, reconnect,
+  backpressure, replay/idempotence on `tools/call`.
+- Migrate types from `mcp-compose/src/deploy/types.ts` (the bits that describe
+  the tunnel, **not** the deploy-specific request/result).
+- Update `mcp-compose/src/deploy/readme.md` and `contract.md` to point at
+  `@casys/mcp-bridge`'s network adapter instead of describing the tunnel inline.
 - Update `mcp-bridge/README.md` to describe the new generalized scope.
 
 ### What this ADR does NOT decide
 
-- The on-the-wire protocol of the network tunnel (MCP-over-WebSocket
-  framing, agent registration handshake schema, replay token format).
-  These are the subject of a follow-up ADR or design doc when impl
-  starts.
-- Whether the `mcp-compose/deploy/` design (Deno Deploy-based ephemeral
-  relay) is still the right shape for `erp-platform`'s permanent
-  multi-tenant routing needs. Likely it is not — `erp-platform` will
-  ship its own integration of the bridge's network server inside its
-  Fresh app rather than spawning per-call workers.
+- The on-the-wire protocol of the network tunnel (MCP-over-WebSocket framing,
+  agent registration handshake schema, replay token format). These are the
+  subject of a follow-up ADR or design doc when impl starts.
+- Whether the `mcp-compose/deploy/` design (Deno Deploy-based ephemeral relay)
+  is still the right shape for `erp-platform`'s permanent multi-tenant routing
+  needs. Likely it is not — `erp-platform` will ship its own integration of the
+  bridge's network server inside its Fresh app rather than spawning per-call
+  workers.
 
 ## Trail of reasoning
 
 Three independent sources converged on the same conclusion:
 
-1. **Erwan (project owner)**: pointed out that semantically a *bridge*
-   and a *tunnel* recover the same concept ("passing traffic between
-   environments that can't talk directly"), and that "displaying in
-   Telegram, displaying in Claude.ai, displaying in LINE — same fight".
+1. **Erwan (project owner)**: pointed out that semantically a _bridge_ and a
+   _tunnel_ recover the same concept ("passing traffic between environments that
+   can't talk directly"), and that "displaying in Telegram, displaying in
+   Claude.ai, displaying in LINE — same fight".
 2. **Claude (assistant)**: confirmed by reading the actual code that
    `bridge/core/` is generic JSON-RPC + WebSocket plumbing, not
-   Telegram-specific. The Telegram/LINE adapters are thin specializations
-   on top of generic primitives.
+   Telegram-specific. The Telegram/LINE adapters are thin specializations on top
+   of generic primitives.
 3. **Codex (independent review)**: initially recommended a new
-   `@casys/mcp-tunnel` package on SRP grounds, before the semantic +
-   code-reuse arguments were laid out. The revision is consistent with
-   Codex's own caveat that "compose/deploy can become the first
-   consumer/reference" — i.e. the primitive belongs upstream of
-   compose, which now applies to bridge as well.
+   `@casys/mcp-tunnel` package on SRP grounds, before the semantic + code-reuse
+   arguments were laid out. The revision is consistent with Codex's own caveat
+   that "compose/deploy can become the first consumer/reference" — i.e. the
+   primitive belongs upstream of compose, which now applies to bridge as well.

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-bridge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Bridge MCP Apps (interactive UI via MCP protocol) to messaging platforms (Telegram Mini Apps, LINE LIFF)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./adapters/network": {
+      "import": "./dist/adapters/network.js",
+      "types": "./dist/adapters/network.d.ts"
     }
   },
   "scripts": {

--- a/packages/bridge/scripts/build-npm.ts
+++ b/packages/bridge/scripts/build-npm.ts
@@ -25,7 +25,10 @@ console.log(`[build-npm] Version: ${VERSION}`);
 await emptyDir("./dist-node");
 
 await build({
-  entryPoints: ["./src/mod.ts"],
+  entryPoints: [
+    "./src/mod.ts",
+    { name: "./adapters/network", path: "./src/adapters/network/mod.ts" },
+  ],
   outDir: "./dist-node",
   shims: {
     deno: false,
@@ -91,6 +94,11 @@ pkg.exports = {
     types: "./esm/mod.d.ts",
     import: "./esm/mod.js",
     require: "./script/mod.js",
+  },
+  "./adapters/network": {
+    types: "./esm/adapters/network.d.ts",
+    import: "./esm/adapters/network.js",
+    require: "./script/adapters/network.js",
   },
 };
 await Deno.writeTextFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n");

--- a/packages/bridge/scripts/build-npm.ts
+++ b/packages/bridge/scripts/build-npm.ts
@@ -96,11 +96,55 @@ pkg.exports = {
     require: "./script/mod.js",
   },
   "./adapters/network": {
-    types: "./esm/adapters/network.d.ts",
-    import: "./esm/adapters/network.js",
-    require: "./script/adapters/network.js",
+    types: "./esm/adapters/network/mod.d.ts",
+    import: "./esm/adapters/network/mod.js",
+    require: "./script/adapters/network/mod.js",
   },
 };
 await Deno.writeTextFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 
+await smokeTestNetworkAdapterSubpath();
+
 console.log("\n[build-npm] Done. Output in ./dist-node/");
+
+async function smokeTestNetworkAdapterSubpath(): Promise<void> {
+  const tempConsumer = await Deno.makeTempDir({
+    prefix: "mcp-bridge-npm-smoke-",
+  });
+  try {
+    const packageScope = `${tempConsumer}/node_modules/@casys`;
+    await Deno.mkdir(packageScope, { recursive: true });
+    await Deno.symlink(
+      new URL("../dist-node", import.meta.url).pathname,
+      `${packageScope}/mcp-bridge`,
+      { type: "dir" },
+    );
+    const command = new Deno.Command("node", {
+      cwd: tempConsumer,
+      args: [
+        "--input-type=module",
+        "--eval",
+        [
+          "const mod = await import('@casys/mcp-bridge/adapters/network');",
+          "if (typeof mod.NetworkRelay !== 'function') {",
+          "  throw new Error('NetworkRelay export missing');",
+          "}",
+        ].join("\n"),
+      ],
+    });
+    const result = await command.output();
+    if (!result.success) {
+      const stderr = new TextDecoder().decode(result.stderr).trim();
+      const stdout = new TextDecoder().decode(result.stdout).trim();
+      throw new Error(
+        [
+          "[build-npm] npm subpath smoke test failed",
+          stdout && `stdout:\n${stdout}`,
+          stderr && `stderr:\n${stderr}`,
+        ].filter(Boolean).join("\n"),
+      );
+    }
+  } finally {
+    await Deno.remove(tempConsumer, { recursive: true });
+  }
+}

--- a/packages/bridge/skills/SKILL.md
+++ b/packages/bridge/skills/SKILL.md
@@ -2,15 +2,22 @@
 
 **Registry:** `jsr:@casys/mcp-bridge` | **Runtime:** Deno
 
-Bridge MCP Apps (interactive HTML UIs delivered via the MCP protocol) to messaging platform webviews — Telegram Mini Apps and LINE LIFF.
+Bridge MCP Apps (interactive HTML UIs delivered via the MCP protocol) to
+messaging platform webviews — Telegram Mini Apps and LINE LIFF.
 
 ---
 
 ## What it does
 
-`@casys/mcp-bridge` solves one problem: an MCP App's HTML runs inside a platform webview (Telegram, LINE) that does not speak the MCP protocol. The bridge injects a `bridge.js` script into the served HTML, which intercepts `postMessage` calls from the MCP App SDK and routes them over WebSocket to a local HTTP resource server. The resource server forwards those JSON-RPC messages to the MCP backend and relays responses back.
+`@casys/mcp-bridge` solves one problem: an MCP App's HTML runs inside a platform
+webview (Telegram, LINE) that does not speak the MCP protocol. The bridge
+injects a `bridge.js` script into the served HTML, which intercepts
+`postMessage` calls from the MCP App SDK and routes them over WebSocket to a
+local HTTP resource server. The resource server forwards those JSON-RPC messages
+to the MCP backend and relays responses back.
 
-The result: unmodified MCP App HTML works inside Telegram Mini Apps without any changes to the app code.
+The result: unmodified MCP App HTML works inside Telegram Mini Apps without any
+changes to the app code.
 
 ---
 
@@ -37,10 +44,12 @@ MCP Backend  (JsonRpcMcpBackend or custom McpBackend)
 ```
 
 **bridge.js** runs inside the webview. It:
+
 - Monkey-patches `window.parent.postMessage` to intercept MCP JSON-RPC
 - Handles `ui/initialize` locally (builds `HostContext` from platform SDK)
 - Forwards all other messages to the resource server via WebSocket
-- Replays platform lifecycle events (`themeChanged`, `viewportChanged`) as MCP notifications
+- Replays platform lifecycle events (`themeChanged`, `viewportChanged`) as MCP
+  notifications
 
 The resource server and backend run server-side in Deno.
 
@@ -53,8 +62,13 @@ deno add jsr:@casys/mcp-bridge
 ```
 
 Import:
+
 ```ts
-import { startResourceServer, JsonRpcMcpBackend, TelegramPlatformAdapter } from "@casys/mcp-bridge";
+import {
+  JsonRpcMcpBackend,
+  startResourceServer,
+  TelegramPlatformAdapter,
+} from "@casys/mcp-bridge";
 ```
 
 ---
@@ -62,7 +76,7 @@ import { startResourceServer, JsonRpcMcpBackend, TelegramPlatformAdapter } from 
 ## Quick start — Telegram
 
 ```ts
-import { startResourceServer, JsonRpcMcpBackend } from "@casys/mcp-bridge";
+import { JsonRpcMcpBackend, startResourceServer } from "@casys/mcp-bridge";
 
 const backend = new JsonRpcMcpBackend({
   endpointUrl: "http://localhost:3000/mcp",
@@ -81,60 +95,103 @@ console.log("Resource server:", server.baseUrl);
 // bridge.js is automatically injected.
 ```
 
-**Telegram requires `telegramBotToken` or a custom `auth` handler.** Omitting both throws at startup.
+**Telegram requires `telegramBotToken` or a custom `auth` handler.** Omitting
+both throws at startup.
 
-The bot then opens the Mini App to `{server.baseUrl}/app/my-app/index.html?...` as a Telegram Web App URL.
+The bot then opens the Mini App to `{server.baseUrl}/app/my-app/index.html?...`
+as a Telegram Web App URL.
 
 ---
 
 ## Platform support
 
-| Platform | Adapter | Auth | Theme | Lifecycle events |
-|----------|---------|------|-------|-----------------|
-| Telegram | `TelegramPlatformAdapter` | HMAC-SHA256 initData | `--color-*` CSS vars via `HostContext.styles` | theme-changed, viewport-changed, activated, deactivated |
-| LINE | `LineAdapter` (extends `BasePostMessageAdapter`) | None built-in | Not implemented | Not implemented |
+| Platform | Adapter                                          | Auth                 | Theme                                         | Lifecycle events                                        |
+| -------- | ------------------------------------------------ | -------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| Telegram | `TelegramPlatformAdapter`                        | HMAC-SHA256 initData | `--color-*` CSS vars via `HostContext.styles` | theme-changed, viewport-changed, activated, deactivated |
+| LINE     | `LineAdapter` (extends `BasePostMessageAdapter`) | None built-in        | Not implemented                               | Not implemented                                         |
 
-LINE support is minimal. `LineAdapter` is a thin `postMessage` wrapper — it does not initialize the LIFF SDK, does not handle auth, and does not emit lifecycle events.
+LINE support is minimal. `LineAdapter` is a thin `postMessage` wrapper — it does
+not initialize the LIFF SDK, does not handle auth, and does not emit lifecycle
+events.
 
 ---
 
 ## Security
 
 **Telegram auth (HMAC-SHA256):**
-- On WebSocket connect, `bridge.js` sends `{ type: "auth", initData: "..." }` before any JSON-RPC traffic.
-- The resource server validates the Telegram `initData` signature against the bot token.
-- Algorithm: HMAC-SHA256 using key `HMAC-SHA256("WebAppData", botToken)`, compared against `hash` param in initData.
+
+- On WebSocket connect, `bridge.js` sends `{ type: "auth", initData: "..." }`
+  before any JSON-RPC traffic.
+- The resource server validates the Telegram `initData` signature against the
+  bot token.
+- Algorithm: HMAC-SHA256 using key `HMAC-SHA256("WebAppData", botToken)`,
+  compared against `hash` param in initData.
 - `auth_date` freshness is checked; default max age is 24 hours (86400 seconds).
-- Unauthenticated sessions receive `auth_error` and the WebSocket is closed (code 4001/4003).
-- After success, `session.authenticated = true`, `session.userId`, `session.username`, and `session.authContext` are populated.
+- Unauthenticated sessions receive `auth_error` and the WebSocket is closed
+  (code 4001/4003).
+- After success, `session.authenticated = true`, `session.userId`,
+  `session.username`, and `session.authContext` are populated.
 
 **CSP:**
-- Every served HTML page gets a `Content-Security-Policy` header via `buildCspHeader`.
-- Base policy: `default-src 'none'`, then explicit allowlist for scripts, styles, images, fonts, and connections.
-- `frame-ancestors 'self'` by default; add platform origins via `csp.frameAncestors`.
-- Inline scripts/styles are allowed by default (`allowInline: true`). Set `allowInline: false` for stricter apps.
 
-**Session limits:** max 10,000 concurrent sessions; sessions expire after 30 minutes of inactivity.
+- Every served HTML page gets a `Content-Security-Policy` header via
+  `buildCspHeader`.
+- Base policy: `default-src 'none'`, then explicit allowlist for scripts,
+  styles, images, fonts, and connections.
+- `frame-ancestors 'self'` by default; add platform origins via
+  `csp.frameAncestors`.
+- Inline scripts/styles are allowed by default (`allowInline: true`). Set
+  `allowInline: false` for stricter apps.
+
+**Session limits:** max 10,000 concurrent sessions; sessions expire after 30
+minutes of inactivity.
 
 ---
 
 ## Key caveats
 
-1. **BridgeClient is iframe/webview-only.** It monkey-patches `window.parent.postMessage`. Outside a real webview context (e.g. Node.js server, test environment), the interception silently no-ops. Never instantiate `BridgeClient` server-side.
+1. **BridgeClient is iframe/webview-only.** It monkey-patches
+   `window.parent.postMessage`. Outside a real webview context (e.g. Node.js
+   server, test environment), the interception silently no-ops. Never
+   instantiate `BridgeClient` server-side.
 
-2. **`bridge.js` vs exported adapters do different things.** `bridge.js` (the injected script) runs inside the webview and handles platform initialization automatically using `TelegramPlatformAdapter`. The exported `TelegramAdapter` and `TelegramPlatformAdapter` classes are for advanced use cases — building custom bridge clients or testing. Most users never import them directly.
+2. **`bridge.js` vs exported adapters do different things.** `bridge.js` (the
+   injected script) runs inside the webview and handles platform initialization
+   automatically using `TelegramPlatformAdapter`. The exported `TelegramAdapter`
+   and `TelegramPlatformAdapter` classes are for advanced use cases — building
+   custom bridge clients or testing. Most users never import them directly.
 
-3. **`TelegramAdapter` vs `TelegramPlatformAdapter`:** `TelegramAdapter` extends `BasePostMessageAdapter` (raw postMessage bridge). `TelegramPlatformAdapter` implements the full `PlatformAdapter` interface with theme extraction, viewport tracking, safe area insets, and lifecycle events. Use `TelegramPlatformAdapter` when building a custom `BridgeClient`.
+3. **`TelegramAdapter` vs `TelegramPlatformAdapter`:** `TelegramAdapter` extends
+   `BasePostMessageAdapter` (raw postMessage bridge). `TelegramPlatformAdapter`
+   implements the full `PlatformAdapter` interface with theme extraction,
+   viewport tracking, safe area insets, and lifecycle events. Use
+   `TelegramPlatformAdapter` when building a custom `BridgeClient`.
 
-4. **`containerDimensions.maxHeight` not `height`.** `TelegramPlatformAdapter.getContainerDimensions()` returns `{ width, maxHeight }` where `maxHeight = tg.viewportStableHeight`. The `height` field is not set. MCP Apps that read `containerDimensions.height` will get `undefined`.
+4. **`containerDimensions.maxHeight` not `height`.**
+   `TelegramPlatformAdapter.getContainerDimensions()` returns
+   `{ width, maxHeight }` where `maxHeight = tg.viewportStableHeight`. The
+   `height` field is not set. MCP Apps that read `containerDimensions.height`
+   will get `undefined`.
 
-5. **Locale comes from `navigator.language`, not Telegram.** `TelegramPlatformAdapter` reads locale from the browser's `navigator.language`, not from `initDataUnsafe.user.language_code`. On Telegram for Android, these can differ.
+5. **Locale comes from `navigator.language`, not Telegram.**
+   `TelegramPlatformAdapter` reads locale from the browser's
+   `navigator.language`, not from `initDataUnsafe.user.language_code`. On
+   Telegram for Android, these can differ.
 
-6. **`sendMessage` (sendData) closes the Mini App.** `TelegramPlatformAdapter.sendMessage()` calls `tg.sendData()`, which sends data back to the bot and immediately closes the webview. This is a Telegram limitation, not a bridge bug.
+6. **`sendMessage` (sendData) closes the Mini App.**
+   `TelegramPlatformAdapter.sendMessage()` calls `tg.sendData()`, which sends
+   data back to the bot and immediately closes the webview. This is a Telegram
+   limitation, not a bridge bug.
 
-7. **Port 0 = OS-assigned.** `BridgeOptions.resourceServerPort` defaults to 0, meaning the OS picks an available port. Always read `server.baseUrl` after `startResourceServer` returns — don't hardcode a port.
+7. **Port 0 = OS-assigned.** `BridgeOptions.resourceServerPort` defaults to 0,
+   meaning the OS picks an available port. Always read `server.baseUrl` after
+   `startResourceServer` returns — don't hardcode a port.
 
-8. **Tool results via `?ref=`.** Use `server.storeToolResult(data)` to get a ref string, then append `?ref=<ref>` to the page URL. When the page is served, the resource server automatically attaches a `ui/notifications/tool-result` notification to the session. Results expire after 5 minutes and are single-use.
+8. **Tool results via `?ref=`.** Use `server.storeToolResult(data)` to get a ref
+   string, then append `?ref=<ref>` to the page URL. When the page is served,
+   the resource server automatically attaches a `ui/notifications/tool-result`
+   notification to the session. Results expire after 5 minutes and are
+   single-use.
 
 ---
 

--- a/packages/bridge/skills/references/api.md
+++ b/packages/bridge/skills/references/api.md
@@ -9,10 +9,11 @@ Version 0.2.0. All exports from `src/mod.ts`.
 Start the HTTP resource server. Returns a `ResourceServer` instance.
 
 ```ts
-function startResourceServer(config: ResourceServerConfig): ResourceServer
+function startResourceServer(config: ResourceServerConfig): ResourceServer;
 ```
 
-**Throws** if `platform === "telegram"` and neither `telegramBotToken` nor `auth` is provided.
+**Throws** if `platform === "telegram"` and neither `telegramBotToken` nor
+`auth` is provided.
 
 ### `ResourceServerConfig`
 
@@ -22,7 +23,7 @@ interface ResourceServerConfig {
   assetDirectories: Record<string, string>;
 
   // Required: platform name used when creating sessions and configuring bridge.js
-  platform: string;  // "telegram" | "line" | any string
+  platform: string; // "telegram" | "line" | any string
 
   // Bridge options (port, CORS, debug)
   options?: BridgeOptions;
@@ -45,11 +46,20 @@ interface ResourceServerConfig {
 
   // Called on every authenticated JSON-RPC message before backend.handleMessage()
   // Return null to fall through to backend
-  onMessage?: (session: BridgeSession, message: McpAppsMessage) => Promise<McpAppsMessage | null>;
+  onMessage?: (
+    session: BridgeSession,
+    message: McpAppsMessage,
+  ) => Promise<McpAppsMessage | null>;
 
   // Custom HTTP route handler for requests not matching built-in paths
   // Return Response, { html, pendingNotifications? }, or null (404)
-  onHttpRequest?: (request: Request) => Promise<Response | { html: string; pendingNotifications?: PendingNotification[] } | null>;
+  onHttpRequest?: (
+    request: Request,
+  ) => Promise<
+    | Response
+    | { html: string; pendingNotifications?: PendingNotification[] }
+    | null
+  >;
 }
 ```
 
@@ -57,9 +67,9 @@ interface ResourceServerConfig {
 
 ```ts
 interface BridgeOptions {
-  resourceServerPort?: number;    // Default: 0 (OS-assigned)
-  allowedOrigins?: readonly string[];  // Default: ["*"]
-  debug?: boolean;                // Default: false
+  resourceServerPort?: number; // Default: 0 (OS-assigned)
+  allowedOrigins?: readonly string[]; // Default: ["*"]
+  debug?: boolean; // Default: false
 }
 ```
 
@@ -67,14 +77,15 @@ interface BridgeOptions {
 
 ```ts
 interface CspOptions {
-  scriptSources?: readonly string[];    // Added to script-src
-  connectSources?: readonly string[];   // Added to connect-src
-  frameAncestors?: readonly string[];   // Added to frame-ancestors
-  allowInline?: boolean;                // Default: true (unsafe-inline)
+  scriptSources?: readonly string[]; // Added to script-src
+  connectSources?: readonly string[]; // Added to connect-src
+  frameAncestors?: readonly string[]; // Added to frame-ancestors
+  allowInline?: boolean; // Default: true (unsafe-inline)
 }
 ```
 
-Default CSP (no options): `default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'`
+Default CSP (no options):
+`default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'`
 
 ---
 
@@ -82,11 +93,11 @@ Default CSP (no options): `default-src 'none'; script-src 'self' 'unsafe-inline'
 
 ```ts
 interface ResourceServer {
-  readonly baseUrl: string;           // e.g. "http://localhost:54321"
-  readonly sessions: SessionStore;    // Live session store
+  readonly baseUrl: string; // e.g. "http://localhost:54321"
+  readonly sessions: SessionStore; // Live session store
 
   // Store a tool result for delivery via ?ref= URL param. Expires in 5 minutes.
-  storeToolResult(result: ToolResultData): string;  // returns ref string
+  storeToolResult(result: ToolResultData): string; // returns ref string
 
   // Retrieve and consume a stored result (single-use).
   consumeToolResult(ref: string): ToolResultData | undefined;
@@ -111,10 +122,11 @@ interface ToolResultData {
 
 ### `buildToolResultFromData(data)`
 
-Converts `ToolResultData` into a `PendingNotification` with method `ui/notifications/tool-result`.
+Converts `ToolResultData` into a `PendingNotification` with method
+`ui/notifications/tool-result`.
 
 ```ts
-function buildToolResultFromData(data: ToolResultData): PendingNotification
+function buildToolResultFromData(data: ToolResultData): PendingNotification;
 ```
 
 ---
@@ -126,7 +138,10 @@ Generic backend for MCP servers exposing an HTTP JSON-RPC endpoint.
 ```ts
 class JsonRpcMcpBackend implements McpBackend {
   constructor(options: JsonRpcMcpBackendOptions);
-  handleMessage(session: BridgeSession, message: McpAppsMessage): Promise<McpAppsMessage | null>;
+  handleMessage(
+    session: BridgeSession,
+    message: McpAppsMessage,
+  ): Promise<McpAppsMessage | null>;
   readResource(uri: string): Promise<string | UiResourceResponse | null>;
 }
 ```
@@ -135,9 +150,9 @@ class JsonRpcMcpBackend implements McpBackend {
 
 ```ts
 interface JsonRpcMcpBackendOptions {
-  endpointUrl: string;                          // Full URL for JSON-RPC POST
-  headers?: Readonly<Record<string, string>>;   // Static request headers
-  fetchFn?: typeof fetch;                       // Custom fetch (testing/custom runtimes)
+  endpointUrl: string; // Full URL for JSON-RPC POST
+  headers?: Readonly<Record<string, string>>; // Static request headers
+  fetchFn?: typeof fetch; // Custom fetch (testing/custom runtimes)
 }
 ```
 
@@ -145,8 +160,14 @@ interface JsonRpcMcpBackendOptions {
 
 ```ts
 interface McpBackend {
-  handleMessage(session: BridgeSession, message: McpAppsMessage): Promise<McpAppsMessage | null>;
-  readResource?(uri: string, request?: Request): Promise<string | UiResourceResponse | null>;
+  handleMessage(
+    session: BridgeSession,
+    message: McpAppsMessage,
+  ): Promise<McpAppsMessage | null>;
+  readResource?(
+    uri: string,
+    request?: Request,
+  ): Promise<string | UiResourceResponse | null>;
 }
 ```
 
@@ -164,7 +185,8 @@ interface UiResourceResponse {
 
 ## `BridgeClient`
 
-Runs inside the webview. Injected automatically by `bridge.js` — only use directly when building custom bridge clients.
+Runs inside the webview. Injected automatically by `bridge.js` — only use
+directly when building custom bridge clients.
 
 ```ts
 class BridgeClient {
@@ -180,12 +202,12 @@ class BridgeClient {
 
 ```ts
 interface BridgeClientOptions {
-  serverUrl: string;              // WebSocket URL of resource server
-  platform: PlatformAdapter;      // Platform adapter instance
-  transport: BridgeTransport;     // Transport (use WebSocketTransport)
-  sessionId: string;              // Session ID from resource server
-  bridgeInfo?: { name: string; version: string };  // Reported in ui/initialize
-  requestTimeoutMs?: number;      // Default: 30000
+  serverUrl: string; // WebSocket URL of resource server
+  platform: PlatformAdapter; // Platform adapter instance
+  transport: BridgeTransport; // Transport (use WebSocketTransport)
+  sessionId: string; // Session ID from resource server
+  bridgeInfo?: { name: string; version: string }; // Reported in ui/initialize
+  requestTimeoutMs?: number; // Default: 30000
 }
 ```
 
@@ -193,44 +215,47 @@ interface BridgeClientOptions {
 
 ## `TelegramPlatformAdapter`
 
-Full `PlatformAdapter` implementation for Telegram Mini Apps. Use with `BridgeClient` for custom client-side bridge setup.
+Full `PlatformAdapter` implementation for Telegram Mini Apps. Use with
+`BridgeClient` for custom client-side bridge setup.
 
 ```ts
 class TelegramPlatformAdapter implements PlatformAdapter {
   readonly name: "telegram";
-  initialize(): Promise<HostContext>;          // calls tg.ready(), tg.expand()
-  getTheme(): "light" | "dark";               // reads tg.colorScheme
-  getContainerDimensions(): ContainerDimensions;  // { width: innerWidth, maxHeight: viewportStableHeight }
-  getAuthData(): Record<string, unknown>;     // { initData, initDataUnsafe, platform, version }
+  initialize(): Promise<HostContext>; // calls tg.ready(), tg.expand()
+  getTheme(): "light" | "dark"; // reads tg.colorScheme
+  getContainerDimensions(): ContainerDimensions; // { width: innerWidth, maxHeight: viewportStableHeight }
+  getAuthData(): Record<string, unknown>; // { initData, initDataUnsafe, platform, version }
   onLifecycleEvent(handler: LifecycleEventHandler): void;
   openLink(url: string): Promise<void>;
-  sendMessage(text: string): Promise<void>;   // calls tg.sendData() — CLOSES the Mini App
+  sendMessage(text: string): Promise<void>; // calls tg.sendData() — CLOSES the Mini App
   destroy(): void;
 }
 ```
 
-Theme mapping from `TelegramThemeParams` to CSS variables (set in `HostContext.styles.variables`):
+Theme mapping from `TelegramThemeParams` to CSS variables (set in
+`HostContext.styles.variables`):
 
-| Telegram param | CSS variable |
-|---|---|
-| `bg_color` | `--color-background-primary` |
-| `secondary_bg_color` | `--color-background-secondary` |
-| `text_color` | `--color-text-primary` |
-| `subtitle_text_color` | `--color-text-secondary` |
-| `section_separator_color` | `--color-border-primary` |
-| `accent_text_color` | `--color-ring-primary` |
-| `hint_color` | `--color-text-hint` |
-| `link_color` | `--color-text-link` |
-| `button_color` | `--color-button-primary` |
-| `button_text_color` | `--color-button-text` |
-| `header_bg_color` | `--color-background-header` |
-| `section_bg_color` | `--color-background-section` |
+| Telegram param            | CSS variable                   |
+| ------------------------- | ------------------------------ |
+| `bg_color`                | `--color-background-primary`   |
+| `secondary_bg_color`      | `--color-background-secondary` |
+| `text_color`              | `--color-text-primary`         |
+| `subtitle_text_color`     | `--color-text-secondary`       |
+| `section_separator_color` | `--color-border-primary`       |
+| `accent_text_color`       | `--color-ring-primary`         |
+| `hint_color`              | `--color-text-hint`            |
+| `link_color`              | `--color-text-link`            |
+| `button_color`            | `--color-button-primary`       |
+| `button_text_color`       | `--color-button-text`          |
+| `header_bg_color`         | `--color-background-header`    |
+| `section_bg_color`        | `--color-background-section`   |
 
 ---
 
 ## `TelegramAdapter`
 
-Minimal postMessage adapter (extends `BasePostMessageAdapter`). Does not handle platform lifecycle, theme, or auth.
+Minimal postMessage adapter (extends `BasePostMessageAdapter`). Does not handle
+platform lifecycle, theme, or auth.
 
 ```ts
 class TelegramAdapter extends BasePostMessageAdapter {
@@ -242,7 +267,8 @@ class TelegramAdapter extends BasePostMessageAdapter {
 
 ## `LineAdapter`
 
-Minimal LINE LIFF adapter (extends `BasePostMessageAdapter`). No LIFF SDK initialization, no auth, no lifecycle events.
+Minimal LINE LIFF adapter (extends `BasePostMessageAdapter`). No LIFF SDK
+initialization, no auth, no lifecycle events.
 
 ```ts
 class LineAdapter extends BasePostMessageAdapter {
@@ -288,13 +314,15 @@ const McpAppsMethod = {
 
 ### `createTelegramAuthHandler(botToken)`
 
-Returns a `BridgeAuthHandler` that validates Telegram `initData` using HMAC-SHA256.
+Returns a `BridgeAuthHandler` that validates Telegram `initData` using
+HMAC-SHA256.
 
 ```ts
-function createTelegramAuthHandler(botToken: string): BridgeAuthHandler
+function createTelegramAuthHandler(botToken: string): BridgeAuthHandler;
 ```
 
-Accepts both `{ type: "auth", initData: "..." }` and `{ type: "auth", payload: { initData: "..." } }`.
+Accepts both `{ type: "auth", initData: "..." }` and
+`{ type: "auth", payload: { initData: "..." } }`.
 
 ### `validateTelegramInitData(initData, botToken, maxAgeSeconds?)`
 
@@ -304,8 +332,8 @@ Low-level validation function. Returns `TelegramAuthResult`.
 async function validateTelegramInitData(
   initData: string,
   botToken: string,
-  maxAgeSeconds?: number,  // Default: 86400
-): Promise<TelegramAuthResult>
+  maxAgeSeconds?: number, // Default: 86400
+): Promise<TelegramAuthResult>;
 ```
 
 ```ts
@@ -364,12 +392,12 @@ Sessions expire after 30 minutes of inactivity. Max 10,000 concurrent sessions.
 
 ```ts
 class SessionStore {
-  constructor(maxAgeMs?: number);  // Default: 30 * 60 * 1000
+  constructor(maxAgeMs?: number); // Default: 30 * 60 * 1000
   create(platform: string): BridgeSession;
   get(id: string): BridgeSession | undefined;
   touch(id: string): void;
   remove(id: string): boolean;
-  cleanup(): number;  // removes expired sessions, returns count
+  cleanup(): number; // removes expired sessions, returns count
   readonly size: number;
   clear(): void;
 }
@@ -406,13 +434,14 @@ interface ContainerDimensions {
 }
 ```
 
-Telegram: `TelegramPlatformAdapter` sets `width` (from `innerWidth`) and `maxHeight` (from `viewportStableHeight`). `height` is not set.
+Telegram: `TelegramPlatformAdapter` sets `width` (from `innerWidth`) and
+`maxHeight` (from `viewportStableHeight`). `height` is not set.
 
 ### `HostContextStyles`
 
 ```ts
 interface HostContextStyles {
-  variables?: Record<string, string>;  // CSS custom properties
+  variables?: Record<string, string>; // CSS custom properties
   css?: { fonts?: string };
 }
 ```
@@ -432,7 +461,12 @@ interface SafeAreaInsets {
 
 ```ts
 interface LifecycleEvent {
-  type: "theme-changed" | "viewport-changed" | "activated" | "deactivated" | "teardown";
+  type:
+    | "theme-changed"
+    | "viewport-changed"
+    | "activated"
+    | "deactivated"
+    | "teardown";
   reason?: string;
 }
 ```
@@ -463,9 +497,17 @@ interface McpToolDeclaration {
 
 ```ts
 type McpAppPermission =
-  | "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups"
-  | "allow-same-origin" | "allow-scripts" | "camera" | "microphone"
-  | "geolocation" | "clipboard-read" | "clipboard-write";
+  | "allow-downloads"
+  | "allow-forms"
+  | "allow-modals"
+  | "allow-popups"
+  | "allow-same-origin"
+  | "allow-scripts"
+  | "camera"
+  | "microphone"
+  | "geolocation"
+  | "clipboard-read"
+  | "clipboard-write";
 ```
 
 ---
@@ -539,8 +581,8 @@ enum JsonRpcErrorCode {
 ## Resource resolver
 
 ```ts
-function parseResourceUri(uri: string): ResourceUri
-function resolveToHttp(uri: ResourceUri, options: ResolveToHttpOptions): string
+function parseResourceUri(uri: string): ResourceUri;
+function resolveToHttp(uri: ResourceUri, options: ResolveToHttpOptions): string;
 ```
 
 ```ts
@@ -557,7 +599,7 @@ interface ResourceUri {
 ## CSP helper
 
 ```ts
-function buildCspHeader(options?: CspOptions): string
+function buildCspHeader(options?: CspOptions): string;
 ```
 
 ---
@@ -565,7 +607,7 @@ function buildCspHeader(options?: CspOptions): string
 ## Telegram SDK bridge
 
 ```ts
-function getTelegramWebApp(): TelegramWebApp
+function getTelegramWebApp(): TelegramWebApp;
 ```
 
 Reads `window.Telegram.WebApp`. Throws if the Telegram SDK is not loaded.

--- a/packages/bridge/skills/references/telegram.md
+++ b/packages/bridge/skills/references/telegram.md
@@ -9,7 +9,7 @@ Reference for Telegram-specific behavior in `@casys/mcp-bridge` v0.2.0.
 ### 1. Server-side (Deno)
 
 ```ts
-import { startResourceServer, JsonRpcMcpBackend } from "@casys/mcp-bridge";
+import { JsonRpcMcpBackend, startResourceServer } from "@casys/mcp-bridge";
 
 const backend = new JsonRpcMcpBackend({
   endpointUrl: "http://localhost:3000/mcp",
@@ -18,17 +18,17 @@ const backend = new JsonRpcMcpBackend({
 const server = startResourceServer({
   platform: "telegram",
   assetDirectories: {
-    "my-app": "./public",  // serves ./public/* at /app/my-app/*
+    "my-app": "./public", // serves ./public/* at /app/my-app/*
   },
   telegramBotToken: Deno.env.get("TELEGRAM_BOT_TOKEN")!,
   backend,
   options: {
-    debug: true,  // logs session creation, auth events, messages
+    debug: true, // logs session creation, auth events, messages
   },
   csp: {
     // Telegram Mini Apps are served in an iframe from web.telegram.org
     frameAncestors: ["https://web.telegram.org"],
-    connectSources: ["wss://*"],  // if your app uses WebSockets directly
+    connectSources: ["wss://*"], // if your app uses WebSockets directly
   },
 });
 
@@ -39,7 +39,9 @@ console.log("App URL:", `${server.baseUrl}/app/my-app/index.html`);
 ### 2. Telegram bot configuration
 
 In `@BotFather`:
-- `/newapp` or `/editapp` → set the Mini App URL to `{server.baseUrl}/app/my-app/index.html`
+
+- `/newapp` or `/editapp` → set the Mini App URL to
+  `{server.baseUrl}/app/my-app/index.html`
 - The URL must be publicly accessible (use ngrok or a tunnel in development)
 
 ### 3. What happens at runtime
@@ -47,12 +49,16 @@ In `@BotFather`:
 1. User opens the Mini App in Telegram
 2. Telegram loads the HTML page from the resource server
 3. `bridge.js` is already injected — it runs immediately
-4. `bridge.js` reads `window.Telegram.WebApp` and calls `tg.ready()` + `tg.expand()`
+4. `bridge.js` reads `window.Telegram.WebApp` and calls `tg.ready()` +
+   `tg.expand()`
 5. `bridge.js` opens a WebSocket to `/bridge?session=<id>`
 6. `bridge.js` sends `{ type: "auth", initData: tg.initData }` on connect
-7. Server validates HMAC-SHA256 and replies `{ type: "auth_ok", userId, username }`
-8. The MCP App's `ui/initialize` is handled locally by `bridge.js` (HostContext built from Telegram SDK)
-9. All subsequent JSON-RPC traffic (tools/call, resources/read, etc.) flows over the WebSocket
+7. Server validates HMAC-SHA256 and replies
+   `{ type: "auth_ok", userId, username }`
+8. The MCP App's `ui/initialize` is handled locally by `bridge.js` (HostContext
+   built from Telegram SDK)
+9. All subsequent JSON-RPC traffic (tools/call, resources/read, etc.) flows over
+   the WebSocket
 
 ---
 
@@ -62,7 +68,9 @@ There are two sets of theme CSS variables with different lifetimes:
 
 ### `--tg-*` variables (from Telegram SDK, set by bridge.js automatically)
 
-Telegram injects these into the page CSS before the Mini App loads. They are always available regardless of the bridge. They reflect raw Telegram theme colors:
+Telegram injects these into the page CSS before the Mini App loads. They are
+always available regardless of the bridge. They reflect raw Telegram theme
+colors:
 
 ```css
 --tg-color-scheme           /* "light" | "dark" */
@@ -76,11 +84,15 @@ Telegram injects these into the page CSS before the Mini App loads. They are alw
 /* etc. */
 ```
 
-Use these in your MCP App HTML for Telegram-native theming if you don't need cross-platform support.
+Use these in your MCP App HTML for Telegram-native theming if you don't need
+cross-platform support.
 
 ### `--color-*` variables (from TelegramPlatformAdapter, set via HostContext)
 
-These are provided in `HostContext.styles.variables` during `ui/initialize` and on `ui/notifications/host-context-changed`. `bridge.js` applies them to `document.documentElement` style. They are semantically named for cross-platform compatibility:
+These are provided in `HostContext.styles.variables` during `ui/initialize` and
+on `ui/notifications/host-context-changed`. `bridge.js` applies them to
+`document.documentElement` style. They are semantically named for cross-platform
+compatibility:
 
 ```css
 --color-background-primary      /* from bg_color */
@@ -97,13 +109,15 @@ These are provided in `HostContext.styles.variables` during `ui/initialize` and 
 --color-ring-primary            /* from accent_text_color */
 ```
 
-`--color-*` variables are only set if the corresponding Telegram theme param is present in `themeParams`. Not all clients provide all params.
+`--color-*` variables are only set if the corresponding Telegram theme param is
+present in `themeParams`. Not all clients provide all params.
 
 ---
 
 ## initData validation (HMAC-SHA256)
 
-The bridge validates `initData` automatically when `telegramBotToken` is provided. The algorithm (per Telegram docs):
+The bridge validates `initData` automatically when `telegramBotToken` is
+provided. The algorithm (per Telegram docs):
 
 1. Parse `initData` as a URL query string
 2. Extract and remove the `hash` parameter
@@ -111,29 +125,34 @@ The bridge validates `initData` automatically when `telegramBotToken` is provide
 4. Join with `\n` to form `data_check_string`
 5. Compute `secret_key = HMAC-SHA256(key="WebAppData", data=botToken)`
 6. Compute `expected = HMAC-SHA256(key=secret_key, data=data_check_string)`
-7. Compare `hex(expected)` with `hash` using `crypto.subtle.verify` (timing-safe)
+7. Compare `hex(expected)` with `hash` using `crypto.subtle.verify`
+   (timing-safe)
 8. Check `auth_date` freshness (default max age: 24 hours)
 
 **After successful validation, `session` contains:**
+
 ```ts
-session.authenticated = true
-session.userId        // Telegram user ID (number)
-session.username      // Telegram username (string | undefined)
-session.principalId   // Same as userId
-session.authContext   // { provider: "telegram", userId, username }
+session.authenticated = true;
+session.userId; // Telegram user ID (number)
+session.username; // Telegram username (string | undefined)
+session.principalId; // Same as userId
+session.authContext; // { provider: "telegram", userId, username }
 ```
 
 **Auth message shape** (sent by bridge.js, handled automatically):
+
 ```json
 { "type": "auth", "initData": "..." }
 ```
 
 Also accepted:
+
 ```json
 { "type": "auth", "payload": { "initData": "..." } }
 ```
 
 **Custom auth handler** (if you need more control):
+
 ```ts
 import { createTelegramAuthHandler } from "@casys/mcp-bridge";
 
@@ -163,17 +182,25 @@ const server = startResourceServer({
 }
 ```
 
-`height` is not set. Reading `hostContext.containerDimensions?.height` returns `undefined`.
+`height` is not set. Reading `hostContext.containerDimensions?.height` returns
+`undefined`.
 
-**Why `maxHeight` and not `height`?** Telegram's `viewportStableHeight` is the stable height after the virtual keyboard fully disappears. Using it as `maxHeight` prevents layout jumps when the keyboard opens/closes. Use `maxHeight` in your CSS (`max-height: var(--container-max-height)`), not `height`.
+**Why `maxHeight` and not `height`?** Telegram's `viewportStableHeight` is the
+stable height after the virtual keyboard fully disappears. Using it as
+`maxHeight` prevents layout jumps when the keyboard opens/closes. Use
+`maxHeight` in your CSS (`max-height: var(--container-max-height)`), not
+`height`.
 
-When the viewport changes (keyboard opens/closes, user resizes), `bridge.js` emits a `ui/notifications/host-context-changed` notification with the updated `containerDimensions`.
+When the viewport changes (keyboard opens/closes, user resizes), `bridge.js`
+emits a `ui/notifications/host-context-changed` notification with the updated
+`containerDimensions`.
 
 ---
 
 ## Locale behavior
 
-`TelegramPlatformAdapter` reads locale from `navigator.language`, not from Telegram's `initDataUnsafe.user.language_code`.
+`TelegramPlatformAdapter` reads locale from `navigator.language`, not from
+Telegram's `initDataUnsafe.user.language_code`.
 
 ```ts
 // What the adapter does:
@@ -182,15 +209,21 @@ private getLocale(): string {
 }
 ```
 
-Consequence: on Telegram for Android, `navigator.language` reflects the **device locale**, while `user.language_code` reflects the **Telegram app locale**. These can differ.
+Consequence: on Telegram for Android, `navigator.language` reflects the **device
+locale**, while `user.language_code` reflects the **Telegram app locale**. These
+can differ.
 
-If you need the Telegram-specific user language, read it from `session.authContext` after authentication:
+If you need the Telegram-specific user language, read it from
+`session.authContext` after authentication:
 
 ```ts
 const telegramLocale = session.authContext?.username; // no — not available here
 ```
 
-Actually, Telegram's `language_code` is in the `initData` `user` object. To get it, parse `initDataUnsafe.user.language_code` from the auth context, or read it from `initData` manually in your `onMessage` handler. The bridge does not expose it on the session object.
+Actually, Telegram's `language_code` is in the `initData` `user` object. To get
+it, parse `initDataUnsafe.user.language_code` from the auth context, or read it
+from `initData` manually in your `onMessage` handler. The bridge does not expose
+it on the session object.
 
 ---
 
@@ -198,20 +231,22 @@ Actually, Telegram's `language_code` is in the `initData` `user` object. To get 
 
 `TelegramPlatformAdapter` listens to these Telegram WebApp events:
 
-| Telegram event | Bridge LifecycleEvent | MCP notification |
-|---|---|---|
-| `themeChanged` | `theme-changed` | `ui/notifications/host-context-changed` with `{ theme }` |
-| `viewportChanged` | `viewport-changed` | `ui/notifications/host-context-changed` with `{ containerDimensions }` |
-| `activated` | `activated` | None (internal only) |
-| `deactivated` | `deactivated` | None (internal only) |
+| Telegram event    | Bridge LifecycleEvent | MCP notification                                                       |
+| ----------------- | --------------------- | ---------------------------------------------------------------------- |
+| `themeChanged`    | `theme-changed`       | `ui/notifications/host-context-changed` with `{ theme }`               |
+| `viewportChanged` | `viewport-changed`    | `ui/notifications/host-context-changed` with `{ containerDimensions }` |
+| `activated`       | `activated`           | None (internal only)                                                   |
+| `deactivated`     | `deactivated`         | None (internal only)                                                   |
 
-`activated`/`deactivated` are tracked but do not produce MCP notifications in v0.2.0. They could be used for session keepalive in the future.
+`activated`/`deactivated` are tracked but do not produce MCP notifications in
+v0.2.0. They could be used for session keepalive in the future.
 
 ---
 
 ## CSP for Telegram Mini Apps
 
-Telegram embeds Mini Apps in an iframe. The `frame-ancestors` directive must include Telegram's web domain:
+Telegram embeds Mini Apps in an iframe. The `frame-ancestors` directive must
+include Telegram's web domain:
 
 ```ts
 startResourceServer({
@@ -225,9 +260,11 @@ startResourceServer({
 });
 ```
 
-Without this, Telegram's web client will refuse to display the Mini App due to CSP violations.
+Without this, Telegram's web client will refuse to display the Mini App due to
+CSP violations.
 
-For Telegram mobile clients (iOS/Android), CSP `frame-ancestors` is not enforced (it's a native webview), so the directive does not break anything.
+For Telegram mobile clients (iOS/Android), CSP `frame-ancestors` is not enforced
+(it's a native webview), so the directive does not break anything.
 
 ---
 
@@ -243,19 +280,27 @@ const ref = server.storeToolResult({
 
 // Return a resource URI to the tool caller
 return {
-  content: [{ type: "resource", resource: { uri: `ui://my-app/result?ref=${ref}` } }],
+  content: [{
+    type: "resource",
+    resource: { uri: `ui://my-app/result?ref=${ref}` },
+  }],
 };
 ```
 
-When the bridge opens `ui://my-app/result?ref=<ref>`, it serves the HTML and automatically prepends a `ui/notifications/tool-result` notification to the session. The MCP App receives it via WebSocket as soon as it connects and calls `ui/initialize`.
+When the bridge opens `ui://my-app/result?ref=<ref>`, it serves the HTML and
+automatically prepends a `ui/notifications/tool-result` notification to the
+session. The MCP App receives it via WebSocket as soon as it connects and calls
+`ui/initialize`.
 
-Stored results expire after 5 minutes. They are single-use (consumed on first retrieval).
+Stored results expire after 5 minutes. They are single-use (consumed on first
+retrieval).
 
 ---
 
 ## Custom HTTP routes for Telegram callbacks
 
-Use `onHttpRequest` for webhook endpoints or custom routes alongside the resource server:
+Use `onHttpRequest` for webhook endpoints or custom routes alongside the
+resource server:
 
 ```ts
 startResourceServer({
@@ -278,10 +323,11 @@ startResourceServer({
       };
     }
 
-    return null;  // 404
+    return null; // 404
   },
   // ...
 });
 ```
 
-Routes handled by built-in paths (`/health`, `/session`, `/bridge`, `/bridge.js`, `/app/`) are never passed to `onHttpRequest`.
+Routes handled by built-in paths (`/health`, `/session`, `/bridge`,
+`/bridge.js`, `/app/`) are never passed to `onHttpRequest`.

--- a/packages/bridge/src/adapters/network/_test-fixtures.ts
+++ b/packages/bridge/src/adapters/network/_test-fixtures.ts
@@ -1,0 +1,5 @@
+import type { NetworkAgentHelloAuthorization } from "./socket-relay.ts";
+
+export function allowInsecureNetworkAgentHelloForTests(): NetworkAgentHelloAuthorization {
+  return { ok: true };
+}

--- a/packages/bridge/src/adapters/network/client.ts
+++ b/packages/bridge/src/adapters/network/client.ts
@@ -235,6 +235,8 @@ export class NetworkTunnelClient {
 function isTerminalClose(reason: NetworkTunnelCloseReason): boolean {
   return reason.code === 4001 ||
     reason.code === 4002 ||
+    // 4003 covers bridge tenant mismatch and missing/required verifier config.
+    reason.code === 4003 ||
     reason.code === 4004 ||
     reason.code === 4009;
 }

--- a/packages/bridge/src/adapters/network/client.ts
+++ b/packages/bridge/src/adapters/network/client.ts
@@ -1,0 +1,78 @@
+import type {
+  NetworkAgentHello,
+  NetworkMessage,
+  NetworkToolCallRequest,
+} from "./types.ts";
+
+export interface NetworkTunnelTransport {
+  connect(url: string): Promise<void>;
+  send(message: NetworkMessage): void;
+  onMessage(handler: (message: NetworkMessage) => void): void;
+  disconnect(): void;
+}
+
+export type NetworkToolCallHandler = (
+  call: NetworkToolCallRequest,
+) => Promise<unknown>;
+
+export interface NetworkTunnelClientOptions {
+  readonly transport: NetworkTunnelTransport;
+  readonly tenantId: string;
+  readonly targetType: string;
+  readonly agentId: string;
+  readonly keyVersion: number;
+  readonly handleToolCall: NetworkToolCallHandler;
+}
+
+export class NetworkTunnelClient {
+  constructor(private readonly options: NetworkTunnelClientOptions) {}
+
+  async start(relayUrl: string): Promise<void> {
+    this.options.transport.onMessage((message) => {
+      void this.handleMessage(message).catch(() => {
+        // Transport-level send failures cannot be reported over the same
+        // failing transport. Keep them out of tool failure semantics.
+      });
+    });
+    await this.options.transport.connect(relayUrl);
+    this.options.transport.send(this.hello());
+  }
+
+  stop(): void {
+    this.options.transport.disconnect();
+  }
+
+  private async handleMessage(message: NetworkMessage): Promise<void> {
+    if (message.type !== "tool.call") return;
+
+    let result: unknown;
+    try {
+      result = await this.options.handleToolCall(message);
+    } catch (err) {
+      this.options.transport.send({
+        type: "error",
+        requestId: message.requestId,
+        code: "TOOL_CALL_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+        context: { toolName: message.toolName },
+      });
+      return;
+    }
+
+    this.options.transport.send({
+      type: "tool.result",
+      requestId: message.requestId,
+      result,
+    });
+  }
+
+  private hello(): NetworkAgentHello {
+    return {
+      type: "agent.hello",
+      tenantId: this.options.tenantId,
+      targetType: this.options.targetType,
+      agentId: this.options.agentId,
+      keyVersion: this.options.keyVersion,
+    };
+  }
+}

--- a/packages/bridge/src/adapters/network/client.ts
+++ b/packages/bridge/src/adapters/network/client.ts
@@ -3,16 +3,31 @@ import type {
   NetworkMessage,
   NetworkToolCallRequest,
 } from "./types.ts";
+import { NETWORK_PROTOCOL_VERSION } from "./types.ts";
+import { NetworkRelayError } from "./relay.ts";
+
+export interface NetworkTunnelCloseReason {
+  readonly code?: number;
+  readonly reason?: string;
+}
 
 export interface NetworkTunnelTransport {
   connect(url: string): Promise<void>;
   send(message: NetworkMessage): void;
   onMessage(handler: (message: NetworkMessage) => void): void;
+  onOpen(handler: () => void): void;
+  onClose(handler: (reason: NetworkTunnelCloseReason) => void): void;
+  onError(handler: (error: unknown) => void): void;
   disconnect(): void;
+}
+
+export interface NetworkToolCallHandlerOptions {
+  readonly signal: AbortSignal;
 }
 
 export type NetworkToolCallHandler = (
   call: NetworkToolCallRequest,
+  options?: NetworkToolCallHandlerOptions,
 ) => Promise<unknown>;
 
 export interface NetworkTunnelClientOptions {
@@ -21,34 +36,171 @@ export interface NetworkTunnelClientOptions {
   readonly targetType: string;
   readonly agentId: string;
   readonly keyVersion: number;
+  readonly reconnect?: NetworkTunnelReconnectOptions | false;
+  readonly onTerminalError?: (error: NetworkRelayError) => void;
   readonly handleToolCall: NetworkToolCallHandler;
 }
 
+export interface NetworkTunnelReconnectOptions {
+  readonly initialDelayMs?: number;
+  readonly maxDelayMs?: number;
+  readonly jitterRatio?: number;
+}
+
 export class NetworkTunnelClient {
+  private readonly pendingToolCalls = new Map<string, AbortController>();
+  private relayUrl: string | null = null;
+  private stopped = true;
+  private reconnecting = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: number | undefined;
+  private resolveReconnectSleep: (() => void) | undefined;
+  private lifecycleRegistered = false;
+
   constructor(private readonly options: NetworkTunnelClientOptions) {}
 
   async start(relayUrl: string): Promise<void> {
+    this.relayUrl = relayUrl;
+    this.stopped = false;
+    this.registerLifecycleHandlers();
+    await this.connectAndHello();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer !== undefined) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.resolveReconnectSleep?.();
+    this.resolveReconnectSleep = undefined;
+    for (const controller of this.pendingToolCalls.values()) {
+      controller.abort(new Error("network tunnel client stopped"));
+    }
+    this.pendingToolCalls.clear();
+    this.options.transport.disconnect();
+  }
+
+  private registerLifecycleHandlers(): void {
+    if (this.lifecycleRegistered) return;
+    this.lifecycleRegistered = true;
     this.options.transport.onMessage((message) => {
       void this.handleMessage(message).catch(() => {
         // Transport-level send failures cannot be reported over the same
         // failing transport. Keep them out of tool failure semantics.
       });
     });
-    await this.options.transport.connect(relayUrl);
+    this.options.transport.onOpen(() => {
+      this.reconnectAttempt = 0;
+    });
+    this.options.transport.onClose((reason) => {
+      this.abortPendingToolCalls(
+        new Error(`network tunnel closed: ${reason.reason ?? "unknown"}`),
+      );
+      if (this.stopped) return;
+      if (isTerminalClose(reason)) {
+        this.stopped = true;
+        this.options.onTerminalError?.(terminalCloseError(reason));
+        return;
+      }
+      this.scheduleReconnect();
+    });
+    this.options.transport.onError((_error) => {
+      if (!this.stopped) this.scheduleReconnect();
+    });
+  }
+
+  private async connectAndHello(): Promise<void> {
+    if (!this.relayUrl) {
+      throw new Error("network tunnel relay URL is not configured");
+    }
+    await this.options.transport.connect(this.relayUrl);
+    if (this.stopped) return;
     this.options.transport.send(this.hello());
   }
 
-  stop(): void {
-    this.options.transport.disconnect();
+  private scheduleReconnect(): void {
+    if (this.options.reconnect === false || this.reconnecting || this.stopped) {
+      return;
+    }
+    this.reconnecting = true;
+    void this.reconnectLoop();
+  }
+
+  private async reconnectLoop(): Promise<void> {
+    try {
+      while (!this.stopped) {
+        await this.sleep(this.nextReconnectDelayMs());
+        if (this.stopped) return;
+        try {
+          await this.connectAndHello();
+          this.reconnectAttempt = 0;
+          return;
+        } catch (err) {
+          if (err instanceof NetworkRelayError) {
+            this.stopped = true;
+            this.options.onTerminalError?.(err);
+            return;
+          }
+        }
+      }
+    } finally {
+      this.reconnecting = false;
+    }
+  }
+
+  private nextReconnectDelayMs(): number {
+    const options = this.options.reconnect === false
+      ? undefined
+      : this.options.reconnect;
+    const initialDelayMs = options?.initialDelayMs ?? 1_000;
+    const maxDelayMs = options?.maxDelayMs ?? 60_000;
+    const jitterRatio = options?.jitterRatio ?? 0.2;
+    const base = Math.min(
+      maxDelayMs,
+      initialDelayMs * 2 ** this.reconnectAttempt++,
+    );
+    if (jitterRatio <= 0 || base <= 0) return base;
+    const jitter = base * jitterRatio * (Math.random() * 2 - 1);
+    return Math.max(0, Math.round(base + jitter));
+  }
+
+  private sleep(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.resolveReconnectSleep = resolve;
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = undefined;
+        this.resolveReconnectSleep = undefined;
+        resolve();
+      }, delayMs);
+    });
+  }
+
+  private abortPendingToolCalls(reason: unknown): void {
+    for (const controller of this.pendingToolCalls.values()) {
+      controller.abort(reason);
+    }
+    this.pendingToolCalls.clear();
   }
 
   private async handleMessage(message: NetworkMessage): Promise<void> {
+    if (message.type === "error" && message.requestId) {
+      this.pendingToolCalls.get(message.requestId)?.abort(message);
+      return;
+    }
+
     if (message.type !== "tool.call") return;
 
+    const controller = new AbortController();
+    this.pendingToolCalls.set(message.requestId, controller);
     let result: unknown;
     try {
-      result = await this.options.handleToolCall(message);
+      result = await this.options.handleToolCall(message, {
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
     } catch (err) {
+      if (controller.signal.aborted) return;
       this.options.transport.send({
         type: "error",
         requestId: message.requestId,
@@ -57,6 +209,8 @@ export class NetworkTunnelClient {
         context: { toolName: message.toolName },
       });
       return;
+    } finally {
+      this.pendingToolCalls.delete(message.requestId);
     }
 
     this.options.transport.send({
@@ -69,10 +223,32 @@ export class NetworkTunnelClient {
   private hello(): NetworkAgentHello {
     return {
       type: "agent.hello",
+      protocolVersion: NETWORK_PROTOCOL_VERSION,
       tenantId: this.options.tenantId,
       targetType: this.options.targetType,
       agentId: this.options.agentId,
       keyVersion: this.options.keyVersion,
     };
   }
+}
+
+function isTerminalClose(reason: NetworkTunnelCloseReason): boolean {
+  return reason.code === 4001 ||
+    reason.code === 4002 ||
+    reason.code === 4004 ||
+    reason.code === 4009;
+}
+
+function terminalCloseError(
+  reason: NetworkTunnelCloseReason,
+): NetworkRelayError {
+  return new NetworkRelayError({
+    code: "TUNNEL_AGENT_DISCONNECTED",
+    context: {
+      closeCode: reason.code,
+      reason: reason.reason,
+    },
+    recovery:
+      "Fix tunnel authentication or protocol configuration before reconnecting.",
+  });
 }

--- a/packages/bridge/src/adapters/network/client_test.ts
+++ b/packages/bridge/src/adapters/network/client_test.ts
@@ -1,0 +1,151 @@
+import { assertEquals } from "@std/assert";
+import { NetworkTunnelClient, type NetworkTunnelTransport } from "./client.ts";
+import type { NetworkMessage } from "./types.ts";
+
+class FakeTransport implements NetworkTunnelTransport {
+  sent: NetworkMessage[] = [];
+  private handler: ((message: NetworkMessage) => void) | null = null;
+
+  connect(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  send(message: NetworkMessage): void {
+    this.sent.push(message);
+  }
+
+  onMessage(handler: (message: NetworkMessage) => void): void {
+    this.handler = handler;
+  }
+
+  disconnect(): void {}
+
+  receive(message: NetworkMessage): void {
+    this.handler?.(message);
+  }
+}
+
+class ResultSendFailingTransport extends FakeTransport {
+  attemptedTypes: string[] = [];
+
+  override send(message: NetworkMessage): void {
+    this.attemptedTypes.push(message.type);
+    if (message.type === "tool.result") {
+      throw new Error("transport send failed");
+    }
+    super.send(message);
+  }
+}
+
+Deno.test("network tunnel client sends hello on start", async () => {
+  const transport = new FakeTransport();
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    handleToolCall: () => Promise.resolve({ ok: true }),
+  });
+
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+
+  assertEquals(transport.sent, [{
+    type: "agent.hello",
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  }]);
+});
+
+Deno.test("network tunnel client handles tool calls", async () => {
+  const transport = new FakeTransport();
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    handleToolCall: (call) =>
+      Promise.resolve({
+        toolName: call.toolName,
+        limit: call.arguments.limit,
+      }),
+  });
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+
+  transport.receive({
+    type: "tool.call",
+    requestId: "req_1",
+    toolName: "erpnext.customer_list",
+    arguments: { limit: 2 },
+    actorSubject: "user_123",
+  });
+  await Promise.resolve();
+
+  assertEquals(transport.sent.at(-1), {
+    type: "tool.result",
+    requestId: "req_1",
+    result: { toolName: "erpnext.customer_list", limit: 2 },
+  });
+});
+
+Deno.test("network tunnel client returns structured error when tool handler fails", async () => {
+  const transport = new FakeTransport();
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    handleToolCall: () => Promise.reject(new Error("ERP unreachable")),
+  });
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+
+  transport.receive({
+    type: "tool.call",
+    requestId: "req_1",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  await Promise.resolve();
+
+  assertEquals(transport.sent.at(-1), {
+    type: "error",
+    requestId: "req_1",
+    code: "TOOL_CALL_FAILED",
+    message: "ERP unreachable",
+    context: { toolName: "erpnext.customer_list" },
+  });
+});
+
+Deno.test("network tunnel client does not misreport transport send failures as tool failures", async () => {
+  const transport = new ResultSendFailingTransport();
+  let toolCalls = 0;
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    handleToolCall: () => {
+      toolCalls++;
+      return Promise.resolve({ ok: true });
+    },
+  });
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+
+  transport.receive({
+    type: "tool.call",
+    requestId: "req_1",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assertEquals(toolCalls, 1);
+  assertEquals(transport.attemptedTypes, ["agent.hello", "tool.result"]);
+});

--- a/packages/bridge/src/adapters/network/client_test.ts
+++ b/packages/bridge/src/adapters/network/client_test.ts
@@ -1,12 +1,21 @@
 import { assertEquals } from "@std/assert";
 import { NetworkTunnelClient, type NetworkTunnelTransport } from "./client.ts";
-import type { NetworkMessage } from "./types.ts";
+import { NetworkRelayError } from "./relay.ts";
+import { NETWORK_PROTOCOL_VERSION, type NetworkMessage } from "./types.ts";
 
 class FakeTransport implements NetworkTunnelTransport {
   sent: NetworkMessage[] = [];
+  connectCalls: string[] = [];
   private handler: ((message: NetworkMessage) => void) | null = null;
+  private openHandler: (() => void) | null = null;
+  private closeHandler:
+    | ((reason: { code?: number; reason?: string }) => void)
+    | null = null;
+  private errorHandler: ((error: unknown) => void) | null = null;
 
-  connect(): Promise<void> {
+  connect(url: string): Promise<void> {
+    this.connectCalls.push(url);
+    this.openHandler?.();
     return Promise.resolve();
   }
 
@@ -18,10 +27,30 @@ class FakeTransport implements NetworkTunnelTransport {
     this.handler = handler;
   }
 
+  onOpen(handler: () => void): void {
+    this.openHandler = handler;
+  }
+
+  onClose(handler: (reason: { code?: number; reason?: string }) => void): void {
+    this.closeHandler = handler;
+  }
+
+  onError(handler: (error: unknown) => void): void {
+    this.errorHandler = handler;
+  }
+
   disconnect(): void {}
 
   receive(message: NetworkMessage): void {
     this.handler?.(message);
+  }
+
+  close(reason: { code?: number; reason?: string } = {}): void {
+    this.closeHandler?.(reason);
+  }
+
+  fail(error: unknown): void {
+    this.errorHandler?.(error);
   }
 }
 
@@ -52,11 +81,90 @@ Deno.test("network tunnel client sends hello on start", async () => {
 
   assertEquals(transport.sent, [{
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_123",
     targetType: "erpnext",
     agentId: "agent_1",
     keyVersion: 1,
   }]);
+});
+
+Deno.test("network tunnel client reconnects and sends fresh hello after recoverable close", async () => {
+  const transport = new FakeTransport();
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    reconnect: { initialDelayMs: 0, maxDelayMs: 0, jitterRatio: 0 },
+    handleToolCall: () => Promise.resolve({ ok: true }),
+  });
+
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+  transport.close({ code: 1006, reason: "abnormal closure" });
+  await waitFor(() => transport.connectCalls.length === 2, "reconnect");
+
+  assertEquals(transport.connectCalls, [
+    "wss://relay.example.test/mcp/_tunnel",
+    "wss://relay.example.test/mcp/_tunnel",
+  ]);
+  assertEquals(
+    transport.sent.filter((message) => message.type === "agent.hello"),
+    [
+      {
+        type: "agent.hello",
+        protocolVersion: NETWORK_PROTOCOL_VERSION,
+        tenantId: "tenant_123",
+        targetType: "erpnext",
+        agentId: "agent_1",
+        keyVersion: 1,
+      },
+      {
+        type: "agent.hello",
+        protocolVersion: NETWORK_PROTOCOL_VERSION,
+        tenantId: "tenant_123",
+        targetType: "erpnext",
+        agentId: "agent_1",
+        keyVersion: 1,
+      },
+    ],
+  );
+
+  client.stop();
+});
+
+Deno.test("network tunnel client stops reconnect loop on terminal close", async () => {
+  const transport = new FakeTransport();
+  let terminalError: NetworkRelayError | undefined;
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    reconnect: { initialDelayMs: 0, maxDelayMs: 0, jitterRatio: 0 },
+    onTerminalError: (error) => {
+      terminalError = error;
+    },
+    handleToolCall: () => Promise.resolve({ ok: true }),
+  });
+
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+  transport.close({ code: 4002, reason: "protocol version mismatch" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assertEquals(terminalError instanceof NetworkRelayError, true);
+  assertEquals(terminalError?.code, "TUNNEL_AGENT_DISCONNECTED");
+  assertEquals(terminalError?.context, {
+    closeCode: 4002,
+    reason: "protocol version mismatch",
+  });
+  assertEquals(
+    terminalError?.recovery,
+    "Fix tunnel authentication or protocol configuration before reconnecting.",
+  );
+  assertEquals(transport.connectCalls.length, 1);
 });
 
 Deno.test("network tunnel client handles tool calls", async () => {
@@ -121,6 +229,52 @@ Deno.test("network tunnel client returns structured error when tool handler fail
   });
 });
 
+Deno.test("network tunnel client aborts local handler when relay cancels request", async () => {
+  const transport = new FakeTransport();
+  let observedSignal: AbortSignal | undefined;
+  let handlerRejected = false;
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    handleToolCall: (_call, options) => {
+      observedSignal = options?.signal;
+      return new Promise((_resolve, reject) => {
+        options?.signal.addEventListener("abort", () => {
+          handlerRejected = true;
+          reject(new Error("aborted"));
+        }, { once: true });
+      });
+    },
+  });
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+
+  transport.receive({
+    type: "tool.call",
+    requestId: "req_1",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  await Promise.resolve();
+
+  assertEquals(observedSignal?.aborted, false);
+  transport.receive({
+    type: "error",
+    requestId: "req_1",
+    code: "TUNNEL_REQUEST_TIMEOUT",
+    message: "timed out",
+    context: {},
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assertEquals(observedSignal?.aborted, true);
+  assertEquals(handlerRejected, true);
+  assertEquals(transport.sent.length, 1);
+});
+
 Deno.test("network tunnel client does not misreport transport send failures as tool failures", async () => {
   const transport = new ResultSendFailingTransport();
   let toolCalls = 0;
@@ -149,3 +303,14 @@ Deno.test("network tunnel client does not misreport transport send failures as t
   assertEquals(toolCalls, 1);
   assertEquals(transport.attemptedTypes, ["agent.hello", "tool.result"]);
 });
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}

--- a/packages/bridge/src/adapters/network/client_test.ts
+++ b/packages/bridge/src/adapters/network/client_test.ts
@@ -167,6 +167,35 @@ Deno.test("network tunnel client stops reconnect loop on terminal close", async 
   assertEquals(transport.connectCalls.length, 1);
 });
 
+Deno.test("network tunnel client treats 4003 close as terminal", async () => {
+  const transport = new FakeTransport();
+  let terminalError: NetworkRelayError | undefined;
+  const client = new NetworkTunnelClient({
+    transport,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+    reconnect: { initialDelayMs: 0, maxDelayMs: 0, jitterRatio: 0 },
+    onTerminalError: (error) => {
+      terminalError = error;
+    },
+    handleToolCall: () => Promise.resolve({ ok: true }),
+  });
+
+  await client.start("wss://relay.example.test/mcp/_tunnel");
+  transport.close({ code: 4003, reason: "agent token verifier required" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assertEquals(terminalError instanceof NetworkRelayError, true);
+  assertEquals(terminalError?.code, "TUNNEL_AGENT_DISCONNECTED");
+  assertEquals(terminalError?.context, {
+    closeCode: 4003,
+    reason: "agent token verifier required",
+  });
+  assertEquals(transport.connectCalls.length, 1);
+});
+
 Deno.test("network tunnel client handles tool calls", async () => {
   const transport = new FakeTransport();
   const client = new NetworkTunnelClient({

--- a/packages/bridge/src/adapters/network/mod.ts
+++ b/packages/bridge/src/adapters/network/mod.ts
@@ -1,0 +1,41 @@
+export { NetworkTunnelClient } from "./client.ts";
+export type {
+  NetworkToolCallHandler,
+  NetworkTunnelClientOptions,
+  NetworkTunnelTransport,
+} from "./client.ts";
+export { NetworkRelay, NetworkRelayError } from "./relay.ts";
+export type {
+  NetworkRelayConcurrencyStrategy,
+  NetworkRelayErrorCode,
+  NetworkRelayOptions,
+  RegisteredNetworkAgent,
+  RelayToolCall,
+} from "./relay.ts";
+export {
+  allowInsecureNetworkAgentHelloForTests,
+  attachNetworkTunnelSocket,
+} from "./socket-relay.ts";
+export type {
+  AttachNetworkTunnelSocketArgs,
+  NetworkAgentHelloAuthorization,
+  NetworkAgentHelloAuthorizer,
+  NetworkTunnelSocket,
+} from "./socket-relay.ts";
+export { WebSocketNetworkTransport } from "./websocket-transport.ts";
+export type {
+  NetworkTransportAuth,
+  NetworkWebSocketFactory,
+  NetworkWebSocketFactoryOptions,
+  NetworkWebSocketLike,
+  WebSocketNetworkTransportOptions,
+} from "./websocket-transport.ts";
+export type {
+  NetworkAgentHello,
+  NetworkAgentReady,
+  NetworkError,
+  NetworkHeartbeat,
+  NetworkMessage,
+  NetworkToolCallRequest,
+  NetworkToolCallResponse,
+} from "./types.ts";

--- a/packages/bridge/src/adapters/network/mod.ts
+++ b/packages/bridge/src/adapters/network/mod.ts
@@ -1,7 +1,10 @@
 export { NetworkTunnelClient } from "./client.ts";
 export type {
   NetworkToolCallHandler,
+  NetworkToolCallHandlerOptions,
   NetworkTunnelClientOptions,
+  NetworkTunnelCloseReason,
+  NetworkTunnelReconnectOptions,
   NetworkTunnelTransport,
 } from "./client.ts";
 export { NetworkRelay, NetworkRelayError } from "./relay.ts";
@@ -10,12 +13,10 @@ export type {
   NetworkRelayErrorCode,
   NetworkRelayOptions,
   RegisteredNetworkAgent,
+  RegisteredNetworkAgentSendOptions,
   RelayToolCall,
 } from "./relay.ts";
-export {
-  allowInsecureNetworkAgentHelloForTests,
-  attachNetworkTunnelSocket,
-} from "./socket-relay.ts";
+export { attachNetworkTunnelSocket } from "./socket-relay.ts";
 export type {
   AttachNetworkTunnelSocketArgs,
   NetworkAgentHelloAuthorization,
@@ -39,3 +40,4 @@ export type {
   NetworkToolCallRequest,
   NetworkToolCallResponse,
 } from "./types.ts";
+export { NETWORK_PROTOCOL_VERSION } from "./types.ts";

--- a/packages/bridge/src/adapters/network/relay.ts
+++ b/packages/bridge/src/adapters/network/relay.ts
@@ -1,0 +1,165 @@
+import type {
+  NetworkToolCallRequest,
+  NetworkToolCallResponse,
+} from "./types.ts";
+
+export interface RegisteredNetworkAgent {
+  readonly tenantId: string;
+  readonly targetType: string;
+  readonly agentId: string;
+  readonly registrationId?: string;
+  readonly send: (
+    message: NetworkToolCallRequest,
+  ) => Promise<NetworkToolCallResponse>;
+}
+
+export interface RelayToolCall {
+  readonly tenantId: string;
+  readonly targetType: string;
+  readonly toolName: string;
+  readonly arguments: Record<string, unknown>;
+  readonly actorSubject: string | null;
+}
+
+export type NetworkRelayConcurrencyStrategy = "parallel" | "reject";
+
+export interface NetworkRelayOptions {
+  readonly requestTimeoutMs?: number;
+  readonly concurrencyStrategy?: NetworkRelayConcurrencyStrategy;
+}
+
+export type NetworkRelayErrorCode =
+  | "NO_TUNNEL_AGENT"
+  | "TUNNEL_AGENT_BUSY"
+  | "TUNNEL_REQUEST_TIMEOUT"
+  | "TUNNEL_REQUEST_ID_MISMATCH";
+
+export class NetworkRelayError extends Error {
+  constructor(
+    public readonly code: NetworkRelayErrorCode,
+    public readonly context: Record<string, unknown>,
+    public readonly recovery: string,
+  ) {
+    super(`${code}: ${recovery}`);
+    this.name = "NetworkRelayError";
+  }
+}
+
+export class NetworkRelay {
+  private readonly agents = new Map<string, RegisteredNetworkAgent>();
+  private readonly inFlightAgents = new Map<string, number>();
+  private readonly requestTimeoutMs: number;
+  private readonly concurrencyStrategy: NetworkRelayConcurrencyStrategy;
+  private nextRequestId = 1;
+
+  constructor(options: NetworkRelayOptions = {}) {
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+    this.concurrencyStrategy = options.concurrencyStrategy ?? "parallel";
+  }
+
+  registerAgent(agent: RegisteredNetworkAgent): void {
+    this.agents.set(this.key(agent.tenantId, agent.targetType), agent);
+  }
+
+  unregisterAgent(
+    tenantId: string,
+    targetType: string,
+    agentId?: string,
+    registrationId?: string,
+  ): void {
+    const key = this.key(tenantId, targetType);
+    if (agentId === undefined) {
+      this.agents.delete(key);
+      return;
+    }
+
+    const agent = this.agents.get(key);
+    if (
+      agent?.agentId === agentId &&
+      (registrationId === undefined ||
+        agent.registrationId === undefined ||
+        agent.registrationId === registrationId)
+    ) {
+      this.agents.delete(key);
+    }
+  }
+
+  async callTool(input: RelayToolCall): Promise<unknown> {
+    const key = this.key(input.tenantId, input.targetType);
+    const agent = this.agents.get(key);
+    if (!agent) {
+      throw new NetworkRelayError(
+        "NO_TUNNEL_AGENT",
+        { tenantId: input.tenantId, targetType: input.targetType },
+        "Connect an agent for this tenant and targetType before calling tools.",
+      );
+    }
+
+    if (
+      this.concurrencyStrategy === "reject" &&
+      (this.inFlightAgents.get(key) ?? 0) > 0
+    ) {
+      throw new NetworkRelayError(
+        "TUNNEL_AGENT_BUSY",
+        { tenantId: input.tenantId, targetType: input.targetType },
+        "Retry after the current tool call completes or configure parallel concurrency.",
+      );
+    }
+
+    const requestId = `net_${this.nextRequestId++}`;
+    this.inFlightAgents.set(key, (this.inFlightAgents.get(key) ?? 0) + 1);
+    let timer: number | undefined;
+    try {
+      const response = await Promise.race([
+        agent.send({
+          type: "tool.call",
+          requestId,
+          toolName: input.toolName,
+          arguments: input.arguments,
+          actorSubject: input.actorSubject,
+        }),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new NetworkRelayError(
+                "TUNNEL_REQUEST_TIMEOUT",
+                {
+                  tenantId: input.tenantId,
+                  targetType: input.targetType,
+                  requestId,
+                },
+                "Check the agent connection and retry the tool call.",
+              ),
+            );
+          }, this.requestTimeoutMs);
+        }),
+      ]);
+
+      if (response.requestId !== requestId) {
+        throw new NetworkRelayError(
+          "TUNNEL_REQUEST_ID_MISMATCH",
+          { expected: requestId, actual: response.requestId },
+          "Drop the agent connection because it returned a mismatched request id.",
+        );
+      }
+
+      return response.result;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      this.decrementInFlight(key);
+    }
+  }
+
+  private decrementInFlight(key: string): void {
+    const count = this.inFlightAgents.get(key) ?? 0;
+    if (count <= 1) {
+      this.inFlightAgents.delete(key);
+      return;
+    }
+    this.inFlightAgents.set(key, count - 1);
+  }
+
+  private key(tenantId: string, targetType: string): string {
+    return JSON.stringify([tenantId, targetType]);
+  }
+}

--- a/packages/bridge/src/adapters/network/relay.ts
+++ b/packages/bridge/src/adapters/network/relay.ts
@@ -8,9 +8,20 @@ export interface RegisteredNetworkAgent {
   readonly targetType: string;
   readonly agentId: string;
   readonly registrationId?: string;
+  /**
+   * Sends a tool call to the registered agent.
+   *
+   * Implementations must honor `options.signal` by rejecting any pending
+   * response once the signal is aborted.
+   */
   readonly send: (
     message: NetworkToolCallRequest,
+    options?: RegisteredNetworkAgentSendOptions,
   ) => Promise<NetworkToolCallResponse>;
+}
+
+export interface RegisteredNetworkAgentSendOptions {
+  readonly signal?: AbortSignal;
 }
 
 export interface RelayToolCall {
@@ -31,22 +42,66 @@ export interface NetworkRelayOptions {
 export type NetworkRelayErrorCode =
   | "NO_TUNNEL_AGENT"
   | "TUNNEL_AGENT_BUSY"
-  | "TUNNEL_REQUEST_TIMEOUT"
-  | "TUNNEL_REQUEST_ID_MISMATCH";
+  | "TUNNEL_AGENT_DISCONNECTED"
+  | "TUNNEL_REQUEST_CANCELLED"
+  | "TUNNEL_REQUEST_TIMEOUT";
+
+export interface NetworkRelayErrorOptions {
+  readonly code: NetworkRelayErrorCode;
+  readonly context?: Record<string, unknown>;
+  readonly recovery: string;
+}
 
 export class NetworkRelayError extends Error {
+  readonly code: NetworkRelayErrorCode;
+  readonly context: Record<string, unknown>;
+  readonly recovery: string;
+
+  constructor(options: NetworkRelayErrorOptions);
   constructor(
-    public readonly code: NetworkRelayErrorCode,
-    public readonly context: Record<string, unknown>,
-    public readonly recovery: string,
+    code: NetworkRelayErrorCode,
+    context: Record<string, unknown>,
+    recovery: string,
+  );
+  constructor(
+    optionsOrCode: NetworkRelayErrorOptions | NetworkRelayErrorCode,
+    context?: Record<string, unknown>,
+    recovery?: string,
   ) {
-    super(`${code}: ${recovery}`);
+    const options = typeof optionsOrCode === "string"
+      ? {
+        code: optionsOrCode,
+        context: context ?? {},
+        recovery: recovery ?? "Retry the network tunnel operation.",
+      }
+      : optionsOrCode;
+    super(`${options.code}: ${options.recovery}`);
+    this.code = options.code;
+    this.context = options.context ?? {};
+    this.recovery = options.recovery;
     this.name = "NetworkRelayError";
   }
 }
 
+interface RegisteredNetworkAgentState {
+  readonly agent: RegisteredNetworkAgent;
+  readonly pending: Map<string, PendingRelayCall>;
+}
+
+interface PendingRelayCall {
+  readonly reject: (error: NetworkRelayError) => void;
+  readonly abort: (error: NetworkRelayError) => void;
+  readonly releaseBusy: () => void;
+}
+
+/**
+ * Relays tool calls to registered network agents.
+ *
+ * By default each agent accepts one in-flight call at a time; pass
+ * `concurrencyStrategy: "parallel"` to opt in to concurrent calls.
+ */
 export class NetworkRelay {
-  private readonly agents = new Map<string, RegisteredNetworkAgent>();
+  private readonly agents = new Map<string, RegisteredNetworkAgentState>();
   private readonly inFlightAgents = new Map<string, number>();
   private readonly requestTimeoutMs: number;
   private readonly concurrencyStrategy: NetworkRelayConcurrencyStrategy;
@@ -54,11 +109,14 @@ export class NetworkRelay {
 
   constructor(options: NetworkRelayOptions = {}) {
     this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
-    this.concurrencyStrategy = options.concurrencyStrategy ?? "parallel";
+    this.concurrencyStrategy = options.concurrencyStrategy ?? "reject";
   }
 
   registerAgent(agent: RegisteredNetworkAgent): void {
-    this.agents.set(this.key(agent.tenantId, agent.targetType), agent);
+    this.agents.set(this.key(agent.tenantId, agent.targetType), {
+      agent,
+      pending: new Map(),
+    });
   }
 
   unregisterAgent(
@@ -66,87 +124,192 @@ export class NetworkRelay {
     targetType: string,
     agentId?: string,
     registrationId?: string,
+    reason: "cancelled" | "disconnected" = "cancelled",
   ): void {
     const key = this.key(tenantId, targetType);
+    const state = this.agents.get(key);
     if (agentId === undefined) {
       this.agents.delete(key);
+      if (state) {
+        this.rejectPendingCalls(
+          state,
+          this.pendingRemovalError(reason, {
+            tenantId,
+            targetType,
+            agentId: state.agent.agentId,
+            registrationId: state.agent.registrationId,
+          }),
+        );
+      }
       return;
     }
 
-    const agent = this.agents.get(key);
     if (
-      agent?.agentId === agentId &&
+      state?.agent.agentId === agentId &&
       (registrationId === undefined ||
-        agent.registrationId === undefined ||
-        agent.registrationId === registrationId)
+        state.agent.registrationId === undefined ||
+        state.agent.registrationId === registrationId)
     ) {
       this.agents.delete(key);
+      this.rejectPendingCalls(
+        state,
+        this.pendingRemovalError(reason, {
+          tenantId,
+          targetType,
+          agentId,
+          registrationId: state.agent.registrationId,
+        }),
+      );
     }
   }
 
   async callTool(input: RelayToolCall): Promise<unknown> {
     const key = this.key(input.tenantId, input.targetType);
-    const agent = this.agents.get(key);
-    if (!agent) {
-      throw new NetworkRelayError(
-        "NO_TUNNEL_AGENT",
-        { tenantId: input.tenantId, targetType: input.targetType },
-        "Connect an agent for this tenant and targetType before calling tools.",
-      );
+    const state = this.agents.get(key);
+    if (!state) {
+      throw new NetworkRelayError({
+        code: "NO_TUNNEL_AGENT",
+        context: { tenantId: input.tenantId, targetType: input.targetType },
+        recovery:
+          "Connect an agent for this tenant and targetType before calling tools.",
+      });
     }
 
     if (
       this.concurrencyStrategy === "reject" &&
       (this.inFlightAgents.get(key) ?? 0) > 0
     ) {
-      throw new NetworkRelayError(
-        "TUNNEL_AGENT_BUSY",
-        { tenantId: input.tenantId, targetType: input.targetType },
-        "Retry after the current tool call completes or configure parallel concurrency.",
-      );
+      throw new NetworkRelayError({
+        code: "TUNNEL_AGENT_BUSY",
+        context: { tenantId: input.tenantId, targetType: input.targetType },
+        recovery:
+          "Retry after the current tool call completes or configure parallel concurrency.",
+      });
     }
 
     const requestId = `net_${this.nextRequestId++}`;
     this.inFlightAgents.set(key, (this.inFlightAgents.get(key) ?? 0) + 1);
+    const abortController = new AbortController();
     let timer: number | undefined;
+    let timedOut = false;
+    let busyReleased = false;
+    const releaseBusy = () => {
+      if (busyReleased) return;
+      busyReleased = true;
+      this.decrementInFlight(key);
+    };
+    const timeoutError = () =>
+      new NetworkRelayError({
+        code: "TUNNEL_REQUEST_TIMEOUT",
+        context: {
+          tenantId: input.tenantId,
+          targetType: input.targetType,
+          requestId,
+        },
+        recovery: "Check the agent connection and retry the tool call.",
+      });
+    const removal = new Promise<never>((_, reject) => {
+      state.pending.set(requestId, {
+        reject,
+        abort: (error) => {
+          if (!abortController.signal.aborted) {
+            abortController.abort(error);
+          }
+        },
+        releaseBusy,
+      });
+    });
+    const toolCall: NetworkToolCallRequest = {
+      type: "tool.call",
+      requestId,
+      toolName: input.toolName,
+      arguments: input.arguments,
+      actorSubject: input.actorSubject,
+    };
+    const sendPromise = state.agent.send(toolCall, {
+      signal: abortController.signal,
+    });
+    void sendPromise.then(
+      () => {
+        state.pending.delete(requestId);
+        releaseBusy();
+      },
+      () => {
+        state.pending.delete(requestId);
+        releaseBusy();
+      },
+    );
     try {
       const response = await Promise.race([
-        agent.send({
-          type: "tool.call",
-          requestId,
-          toolName: input.toolName,
-          arguments: input.arguments,
-          actorSubject: input.actorSubject,
-        }),
+        sendPromise,
+        removal,
         new Promise<never>((_, reject) => {
           timer = setTimeout(() => {
-            reject(
-              new NetworkRelayError(
-                "TUNNEL_REQUEST_TIMEOUT",
-                {
-                  tenantId: input.tenantId,
-                  targetType: input.targetType,
-                  requestId,
-                },
-                "Check the agent connection and retry the tool call.",
-              ),
-            );
+            timedOut = true;
+            const error = timeoutError();
+            if (!abortController.signal.aborted) {
+              abortController.abort(error);
+            }
+            reject(error);
           }, this.requestTimeoutMs);
         }),
       ]);
 
       if (response.requestId !== requestId) {
-        throw new NetworkRelayError(
-          "TUNNEL_REQUEST_ID_MISMATCH",
-          { expected: requestId, actual: response.requestId },
-          "Drop the agent connection because it returned a mismatched request id.",
-        );
+        throw new NetworkRelayError({
+          code: "TUNNEL_AGENT_DISCONNECTED",
+          context: {
+            tenantId: input.tenantId,
+            targetType: input.targetType,
+            expectedRequestId: requestId,
+            actualRequestId: response.requestId,
+          },
+          recovery:
+            "Drop the agent connection because it returned a mismatched request id.",
+        });
       }
 
       return response.result;
     } finally {
       if (timer !== undefined) clearTimeout(timer);
-      this.decrementInFlight(key);
+      if (!timedOut) {
+        state.pending.delete(requestId);
+        releaseBusy();
+      }
+    }
+  }
+
+  private pendingRemovalError(
+    reason: "cancelled" | "disconnected",
+    context: Record<string, unknown>,
+  ): (requestId: string) => NetworkRelayError {
+    if (reason === "disconnected") {
+      return (requestId) =>
+        new NetworkRelayError({
+          code: "TUNNEL_AGENT_DISCONNECTED",
+          context: { ...context, requestId },
+          recovery: "Reconnect the tunnel agent before retrying the tool call.",
+        });
+    }
+
+    return (requestId) =>
+      new NetworkRelayError({
+        code: "TUNNEL_REQUEST_CANCELLED",
+        context: { ...context, requestId },
+        recovery: "Retry after the tunnel agent is registered again.",
+      });
+  }
+
+  private rejectPendingCalls(
+    state: RegisteredNetworkAgentState,
+    errorForRequest: (requestId: string) => NetworkRelayError,
+  ): void {
+    for (const [requestId, pending] of state.pending) {
+      const error = errorForRequest(requestId);
+      state.pending.delete(requestId);
+      pending.abort(error);
+      pending.releaseBusy();
+      pending.reject(error);
     }
   }
 

--- a/packages/bridge/src/adapters/network/relay.ts
+++ b/packages/bridge/src/adapters/network/relay.ts
@@ -226,9 +226,16 @@ export class NetworkRelay {
       arguments: input.arguments,
       actorSubject: input.actorSubject,
     };
-    const sendPromise = state.agent.send(toolCall, {
-      signal: abortController.signal,
-    });
+    let sendPromise: Promise<NetworkToolCallResponse>;
+    try {
+      sendPromise = Promise.resolve(state.agent.send(toolCall, {
+        signal: abortController.signal,
+      }));
+    } catch (err) {
+      state.pending.delete(requestId);
+      releaseBusy();
+      throw err;
+    }
     void sendPromise.then(
       () => {
         state.pending.delete(requestId);

--- a/packages/bridge/src/adapters/network/relay_test.ts
+++ b/packages/bridge/src/adapters/network/relay_test.ts
@@ -49,6 +49,40 @@ Deno.test("relay rejects when no agent is connected", async () => {
   });
 });
 
+Deno.test("relay unregister rejects in-flight calls with a cancellation error", async () => {
+  const relay = new NetworkRelay();
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: () => new Promise(() => {}),
+  });
+
+  const call = relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  const rejection = withTimeout(
+    assertRejects(
+      () => call,
+      NetworkRelayError,
+      "TUNNEL_REQUEST_CANCELLED",
+    ),
+    "in-flight call was not cancelled",
+  );
+
+  relay.unregisterAgent("tenant_123", "erpnext", "agent_1");
+
+  const error = await rejection;
+  assertEquals(error.code, "TUNNEL_REQUEST_CANCELLED");
+  assertEquals(error.context.tenantId, "tenant_123");
+  assertEquals(error.context.targetType, "erpnext");
+  assertEquals(error.context.agentId, "agent_1");
+});
+
 Deno.test("relay keying does not collide when identifiers contain separators", async () => {
   const relay = new NetworkRelay();
   relay.registerAgent({
@@ -96,8 +130,65 @@ Deno.test("relay keying does not collide when identifiers contain separators", a
   );
 });
 
-Deno.test("relay runs concurrent calls to the same agent by default", async () => {
+Deno.test("relay rejects concurrent calls to the same agent by default", async () => {
   const relay = new NetworkRelay();
+  let resolveFirst!: (value: void) => void;
+  const firstSendComplete = new Promise<void>((resolve) => {
+    resolveFirst = resolve;
+  });
+
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: async (message) => {
+      await firstSendComplete;
+      return {
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { ok: true },
+      };
+    },
+  });
+
+  const firstCall = relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+
+  let secondCall: Promise<unknown> | undefined;
+  try {
+    const error = await withTimeout(
+      assertRejects(
+        () => {
+          secondCall = relay.callTool({
+            tenantId: "tenant_123",
+            targetType: "erpnext",
+            toolName: "erpnext.customer_get",
+            arguments: {},
+            actorSubject: null,
+          });
+          return secondCall;
+        },
+        NetworkRelayError,
+        "TUNNEL_AGENT_BUSY",
+      ),
+      "second concurrent call was accepted",
+    );
+    assertEquals(error.code, "TUNNEL_AGENT_BUSY");
+  } finally {
+    resolveFirst();
+    await Promise.allSettled([firstCall, secondCall]);
+  }
+
+  assertEquals(await firstCall, { ok: true });
+});
+
+Deno.test("relay parallel strategy runs concurrent calls to the same agent", async () => {
+  const relay = new NetworkRelay({ concurrencyStrategy: "parallel" });
   const calls: string[] = [];
 
   relay.registerAgent({
@@ -183,16 +274,39 @@ Deno.test("relay reject strategy rejects concurrent calls to the same agent", as
   assertEquals(await firstCall, { ok: true });
 });
 
-Deno.test("relay times out stuck agents and clears busy state", async () => {
+function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: number | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), 20);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+Deno.test("relay keeps agent busy after timeout until send settles", async () => {
   const relay = new NetworkRelay({ requestTimeoutMs: 1 });
-  let shouldHang = true;
+  let finishFirst!: () => void;
+  let firstSignal: AbortSignal | undefined;
+  let calls = 0;
 
   relay.registerAgent({
     tenantId: "tenant_123",
     targetType: "erpnext",
     agentId: "agent_1",
-    send: (message) => {
-      if (shouldHang) return new Promise(() => {});
+    send: (message, options) => {
+      calls++;
+      if (calls === 1) {
+        firstSignal = options?.signal;
+        return new Promise((resolve) => {
+          finishFirst = () =>
+            resolve({
+              type: "tool.result",
+              requestId: message.requestId,
+              result: { late: true },
+            });
+        });
+      }
       return Promise.resolve({
         type: "tool.result",
         requestId: message.requestId,
@@ -201,20 +315,40 @@ Deno.test("relay times out stuck agents and clears busy state", async () => {
     },
   });
 
-  await assertRejects(
-    () =>
-      relay.callTool({
-        tenantId: "tenant_123",
-        targetType: "erpnext",
-        toolName: "erpnext.customer_list",
-        arguments: {},
-        actorSubject: null,
-      }),
-    Error,
-    "TUNNEL_REQUEST_TIMEOUT",
-  );
+  try {
+    const timeout = await assertRejects(
+      () =>
+        relay.callTool({
+          tenantId: "tenant_123",
+          targetType: "erpnext",
+          toolName: "erpnext.customer_list",
+          arguments: {},
+          actorSubject: null,
+        }),
+      NetworkRelayError,
+      "TUNNEL_REQUEST_TIMEOUT",
+    );
+    assertEquals(timeout.code, "TUNNEL_REQUEST_TIMEOUT");
+    assertEquals(firstSignal?.aborted, true);
 
-  shouldHang = false;
+    const busy = await assertRejects(
+      () =>
+        relay.callTool({
+          tenantId: "tenant_123",
+          targetType: "erpnext",
+          toolName: "erpnext.customer_list",
+          arguments: {},
+          actorSubject: null,
+        }),
+      NetworkRelayError,
+      "TUNNEL_AGENT_BUSY",
+    );
+    assertEquals(busy.code, "TUNNEL_AGENT_BUSY");
+  } finally {
+    finishFirst?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
   const result = await relay.callTool({
     tenantId: "tenant_123",
     targetType: "erpnext",
@@ -224,6 +358,45 @@ Deno.test("relay times out stuck agents and clears busy state", async () => {
   });
 
   assertEquals(result, { ok: true });
+});
+
+Deno.test("relay clears busy state after timeout when agent is dropped", async () => {
+  const relay = new NetworkRelay({ requestTimeoutMs: 1 });
+
+  relay.registerAgent({
+    tenantId: "tenant_drop",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: () => new Promise(() => {}),
+  });
+
+  await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_drop",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    NetworkRelayError,
+    "TUNNEL_REQUEST_TIMEOUT",
+  );
+
+  relay.unregisterAgent("tenant_drop", "erpnext", "agent_1");
+
+  await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_drop",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    NetworkRelayError,
+    "NO_TUNNEL_AGENT",
+  );
 });
 
 Deno.test("relay ignores stale unregister from replaced agent", async () => {

--- a/packages/bridge/src/adapters/network/relay_test.ts
+++ b/packages/bridge/src/adapters/network/relay_test.ts
@@ -274,6 +274,51 @@ Deno.test("relay reject strategy rejects concurrent calls to the same agent", as
   assertEquals(await firstCall, { ok: true });
 });
 
+Deno.test("relay frees agent slot when send throws synchronously", async () => {
+  const relay = new NetworkRelay();
+  let calls = 0;
+
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: (message) => {
+      calls++;
+      if (calls === 1) {
+        throw new Error("sync send failed");
+      }
+      return Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { ok: true },
+      });
+    },
+  });
+
+  await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_123",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    Error,
+    "sync send failed",
+  );
+
+  const result = await relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+
+  assertEquals(result, { ok: true });
+});
+
 function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
   let timer: number | undefined;
   const timeout = new Promise<never>((_, reject) => {

--- a/packages/bridge/src/adapters/network/relay_test.ts
+++ b/packages/bridge/src/adapters/network/relay_test.ts
@@ -1,0 +1,305 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { NetworkRelay, NetworkRelayError } from "./relay.ts";
+
+Deno.test("relay routes one tool call to registered agent", async () => {
+  const relay = new NetworkRelay();
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: (message) => {
+      assertEquals(message.type, "tool.call");
+      return Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { ok: true },
+      });
+    },
+  });
+
+  const result = await relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: "user_123",
+  });
+
+  assertEquals(result, { ok: true });
+});
+
+Deno.test("relay rejects when no agent is connected", async () => {
+  const relay = new NetworkRelay();
+  const error = await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_123",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    NetworkRelayError,
+    "NO_TUNNEL_AGENT",
+  );
+  assertEquals(error.code, "NO_TUNNEL_AGENT");
+  assertEquals(error.context, {
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+  });
+});
+
+Deno.test("relay keying does not collide when identifiers contain separators", async () => {
+  const relay = new NetworkRelay();
+  relay.registerAgent({
+    tenantId: "tenant:a",
+    targetType: "erpnext",
+    agentId: "agent_colon_tenant",
+    send: (message) =>
+      Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { agent: "colon-tenant" },
+      }),
+  });
+  relay.registerAgent({
+    tenantId: "tenant",
+    targetType: "a:erpnext",
+    agentId: "agent_colon_target",
+    send: (message) =>
+      Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { agent: "colon-target" },
+      }),
+  });
+
+  assertEquals(
+    await relay.callTool({
+      tenantId: "tenant:a",
+      targetType: "erpnext",
+      toolName: "erpnext.customer_list",
+      arguments: {},
+      actorSubject: null,
+    }),
+    { agent: "colon-tenant" },
+  );
+  assertEquals(
+    await relay.callTool({
+      tenantId: "tenant",
+      targetType: "a:erpnext",
+      toolName: "erpnext.customer_list",
+      arguments: {},
+      actorSubject: null,
+    }),
+    { agent: "colon-target" },
+  );
+});
+
+Deno.test("relay runs concurrent calls to the same agent by default", async () => {
+  const relay = new NetworkRelay();
+  const calls: string[] = [];
+
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: (message) => {
+      calls.push(message.requestId);
+      return Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { requestId: message.requestId },
+      });
+    },
+  });
+
+  const [first, second] = await Promise.all([
+    relay.callTool({
+      tenantId: "tenant_123",
+      targetType: "erpnext",
+      toolName: "erpnext.customer_list",
+      arguments: {},
+      actorSubject: null,
+    }),
+    relay.callTool({
+      tenantId: "tenant_123",
+      targetType: "erpnext",
+      toolName: "erpnext.customer_get",
+      arguments: {},
+      actorSubject: null,
+    }),
+  ]);
+
+  assertEquals(calls, ["net_1", "net_2"]);
+  assertEquals(first, { requestId: "net_1" });
+  assertEquals(second, { requestId: "net_2" });
+});
+
+Deno.test("relay reject strategy rejects concurrent calls to the same agent", async () => {
+  const relay = new NetworkRelay({ concurrencyStrategy: "reject" });
+  let resolveFirst!: (value: void) => void;
+  const firstSendComplete = new Promise<void>((resolve) => {
+    resolveFirst = resolve;
+  });
+
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: async (message) => {
+      await firstSendComplete;
+      return {
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { ok: true },
+      };
+    },
+  });
+
+  const firstCall = relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+
+  const error = await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_123",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    NetworkRelayError,
+    "TUNNEL_AGENT_BUSY",
+  );
+  assertEquals(error.code, "TUNNEL_AGENT_BUSY");
+
+  resolveFirst();
+  assertEquals(await firstCall, { ok: true });
+});
+
+Deno.test("relay times out stuck agents and clears busy state", async () => {
+  const relay = new NetworkRelay({ requestTimeoutMs: 1 });
+  let shouldHang = true;
+
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    send: (message) => {
+      if (shouldHang) return new Promise(() => {});
+      return Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { ok: true },
+      });
+    },
+  });
+
+  await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_123",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    Error,
+    "TUNNEL_REQUEST_TIMEOUT",
+  );
+
+  shouldHang = false;
+  const result = await relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+
+  assertEquals(result, { ok: true });
+});
+
+Deno.test("relay ignores stale unregister from replaced agent", async () => {
+  const relay = new NetworkRelay();
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_old",
+    send: (message) =>
+      Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { agent: "old" },
+      }),
+  });
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_new",
+    send: (message) =>
+      Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { agent: "new" },
+      }),
+  });
+
+  relay.unregisterAgent("tenant_123", "erpnext", "agent_old");
+
+  const result = await relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+
+  assertEquals(result, { agent: "new" });
+});
+
+Deno.test("relay ignores stale unregister when replaced agent reuses same id", async () => {
+  const relay = new NetworkRelay();
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    registrationId: "old",
+    send: (message) =>
+      Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { agent: "old" },
+      }),
+  });
+  relay.registerAgent({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    registrationId: "new",
+    send: (message) =>
+      Promise.resolve({
+        type: "tool.result",
+        requestId: message.requestId,
+        result: { agent: "new" },
+      }),
+  });
+
+  relay.unregisterAgent("tenant_123", "erpnext", "agent_1", "old");
+
+  const result = await relay.callTool({
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+
+  assertEquals(result, { agent: "new" });
+});

--- a/packages/bridge/src/adapters/network/socket-relay.ts
+++ b/packages/bridge/src/adapters/network/socket-relay.ts
@@ -1,0 +1,239 @@
+import type {
+  NetworkAgentHello,
+  NetworkMessage,
+  NetworkToolCallRequest,
+  NetworkToolCallResponse,
+} from "./types.ts";
+import type { NetworkRelay } from "./relay.ts";
+
+export interface NetworkTunnelSocket {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onmessage: ((event: { data: string }) => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+}
+
+export interface AttachNetworkTunnelSocketArgs {
+  readonly relay: NetworkRelay;
+  readonly socket: NetworkTunnelSocket;
+  readonly tenantId: string;
+  readonly helloTimeoutMs?: number;
+  readonly toolCallTimeoutMs?: number;
+  readonly authorizeAgentHello?: NetworkAgentHelloAuthorizer;
+}
+
+export type NetworkAgentHelloAuthorization =
+  | { ok: true }
+  | { ok: false; closeCode: number; reason: string };
+
+export type NetworkAgentHelloAuthorizer = (
+  message: NetworkAgentHello,
+) => NetworkAgentHelloAuthorization | Promise<NetworkAgentHelloAuthorization>;
+
+export function allowInsecureNetworkAgentHelloForTests(): NetworkAgentHelloAuthorization {
+  return { ok: true };
+}
+
+interface PendingToolCall {
+  readonly resolve: (response: NetworkToolCallResponse) => void;
+  readonly reject: (error: Error) => void;
+  readonly timer: number;
+}
+
+let nextRegistrationId = 1;
+
+export function attachNetworkTunnelSocket(
+  args: AttachNetworkTunnelSocketArgs,
+): void {
+  const pending = new Map<string, PendingToolCall>();
+  let registered:
+    | {
+      tenantId: string;
+      targetType: string;
+      agentId: string;
+      registrationId: string;
+    }
+    | null = null;
+  let registering = false;
+  let closed = false;
+  const timeoutMs = args.toolCallTimeoutMs ?? 30_000;
+  const helloTimer = setTimeout(() => {
+    if (!registered && !closed) {
+      args.socket.close(4002, "agent hello timeout");
+    }
+  }, args.helloTimeoutMs ?? 5_000);
+
+  args.socket.onmessage = (event) => {
+    const message = parseNetworkMessage(event.data);
+    if (!message) return;
+
+    if (message.type === "agent.hello") {
+      if (!isValidAgentHello(message)) {
+        args.socket.close(4002, "invalid agent hello");
+        return;
+      }
+      void handleAgentHello(message);
+      return;
+    }
+
+    if (message.type === "tool.result") {
+      const waiter = pending.get(message.requestId);
+      if (!waiter) return;
+      pending.delete(message.requestId);
+      clearTimeout(waiter.timer);
+      waiter.resolve(message);
+      return;
+    }
+
+    if (message.type === "error" && message.requestId) {
+      const waiter = pending.get(message.requestId);
+      if (!waiter) return;
+      pending.delete(message.requestId);
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error(`${message.code}: ${message.message}`));
+    }
+  };
+
+  const cleanup = () => {
+    closed = true;
+    clearTimeout(helloTimer);
+    if (registered) {
+      args.relay.unregisterAgent(
+        registered.tenantId,
+        registered.targetType,
+        registered.agentId,
+        registered.registrationId,
+      );
+      registered = null;
+    }
+    for (const [requestId, waiter] of pending) {
+      pending.delete(requestId);
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error("TUNNEL_SOCKET_CLOSED"));
+    }
+  };
+
+  args.socket.onclose = cleanup;
+  args.socket.onerror = cleanup;
+
+  async function handleAgentHello(message: NetworkAgentHello): Promise<void> {
+    if (registered || registering) {
+      args.socket.close(4008, "agent already registered");
+      return;
+    }
+    if (message.tenantId !== args.tenantId) {
+      args.socket.close(4003, "tenant mismatch");
+      return;
+    }
+
+    registering = true;
+    try {
+      let authorization: NetworkAgentHelloAuthorization;
+      try {
+        authorization = await (args.authorizeAgentHello?.(message) ?? {
+          ok: false,
+          closeCode: 4001,
+          reason: "agent authorization required",
+        });
+      } catch {
+        args.socket.close(4001, "agent authorization failed");
+        return;
+      }
+      if (!authorization.ok) {
+        args.socket.close(authorization.closeCode, authorization.reason);
+        return;
+      }
+      if (closed) return;
+
+      registered = {
+        tenantId: message.tenantId,
+        targetType: message.targetType,
+        agentId: message.agentId,
+        registrationId: `socket_${nextRegistrationId++}`,
+      };
+      clearTimeout(helloTimer);
+      args.relay.registerAgent({
+        tenantId: message.tenantId,
+        targetType: message.targetType,
+        agentId: message.agentId,
+        registrationId: registered.registrationId,
+        send: (toolCall) =>
+          sendToolCall(args.socket, pending, toolCall, timeoutMs),
+      });
+      args.socket.send(JSON.stringify(agentReady(message)));
+    } finally {
+      registering = false;
+    }
+  }
+}
+
+function isValidAgentHello(
+  message: NetworkMessage,
+): message is NetworkAgentHello {
+  return message.type === "agent.hello" &&
+    isNonEmptyString(message.tenantId) &&
+    isNonEmptyString(message.targetType) &&
+    isNonEmptyString(message.agentId) &&
+    Number.isInteger(message.keyVersion) &&
+    message.keyVersion > 0;
+}
+
+function sendToolCall(
+  socket: NetworkTunnelSocket,
+  pending: Map<string, PendingToolCall>,
+  toolCall: NetworkToolCallRequest,
+  timeoutMs: number,
+): Promise<NetworkToolCallResponse> {
+  if (pending.has(toolCall.requestId)) {
+    return Promise.reject(
+      new Error(`DUPLICATE_TUNNEL_REQUEST requestId=${toolCall.requestId}`),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pending.delete(toolCall.requestId);
+      reject(
+        new Error(`TUNNEL_TOOL_CALL_TIMEOUT requestId=${toolCall.requestId}`),
+      );
+    }, timeoutMs);
+    pending.set(toolCall.requestId, { resolve, reject, timer });
+
+    try {
+      socket.send(JSON.stringify(toolCall));
+    } catch (err) {
+      pending.delete(toolCall.requestId);
+      clearTimeout(timer);
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+function parseNetworkMessage(raw: string): NetworkMessage | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) && typeof parsed.type === "string"
+      ? parsed as unknown as NetworkMessage
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function agentReady(message: NetworkAgentHello): NetworkMessage {
+  return {
+    type: "agent.ready",
+    tenantId: message.tenantId,
+    targetType: message.targetType,
+    agentId: message.agentId,
+  };
+}

--- a/packages/bridge/src/adapters/network/socket-relay.ts
+++ b/packages/bridge/src/adapters/network/socket-relay.ts
@@ -4,7 +4,12 @@ import type {
   NetworkToolCallRequest,
   NetworkToolCallResponse,
 } from "./types.ts";
-import type { NetworkRelay } from "./relay.ts";
+import { NETWORK_PROTOCOL_VERSION } from "./types.ts";
+import {
+  type NetworkRelay,
+  NetworkRelayError,
+  type RegisteredNetworkAgentSendOptions,
+} from "./relay.ts";
 
 export interface NetworkTunnelSocket {
   send(data: string): void;
@@ -31,14 +36,12 @@ export type NetworkAgentHelloAuthorizer = (
   message: NetworkAgentHello,
 ) => NetworkAgentHelloAuthorization | Promise<NetworkAgentHelloAuthorization>;
 
-export function allowInsecureNetworkAgentHelloForTests(): NetworkAgentHelloAuthorization {
-  return { ok: true };
-}
-
 interface PendingToolCall {
   readonly resolve: (response: NetworkToolCallResponse) => void;
   readonly reject: (error: Error) => void;
   readonly timer: number;
+  readonly signal?: AbortSignal;
+  readonly onAbort?: () => void;
 }
 
 let nextRegistrationId = 1;
@@ -69,6 +72,10 @@ export function attachNetworkTunnelSocket(
     if (!message) return;
 
     if (message.type === "agent.hello") {
+      if (!hasSupportedProtocolVersion(message)) {
+        args.socket.close(4002, "protocol version mismatch");
+        return;
+      }
       if (!isValidAgentHello(message)) {
         args.socket.close(4002, "invalid agent hello");
         return;
@@ -81,7 +88,7 @@ export function attachNetworkTunnelSocket(
       const waiter = pending.get(message.requestId);
       if (!waiter) return;
       pending.delete(message.requestId);
-      clearTimeout(waiter.timer);
+      cleanupPendingToolCall(waiter);
       waiter.resolve(message);
       return;
     }
@@ -90,7 +97,7 @@ export function attachNetworkTunnelSocket(
       const waiter = pending.get(message.requestId);
       if (!waiter) return;
       pending.delete(message.requestId);
-      clearTimeout(waiter.timer);
+      cleanupPendingToolCall(waiter);
       waiter.reject(new Error(`${message.code}: ${message.message}`));
     }
   };
@@ -104,13 +111,22 @@ export function attachNetworkTunnelSocket(
         registered.targetType,
         registered.agentId,
         registered.registrationId,
+        "disconnected",
       );
       registered = null;
     }
     for (const [requestId, waiter] of pending) {
       pending.delete(requestId);
-      clearTimeout(waiter.timer);
-      waiter.reject(new Error("TUNNEL_SOCKET_CLOSED"));
+      cleanupPendingToolCall(waiter);
+      waiter.reject(
+        new NetworkRelayError({
+          code: "TUNNEL_AGENT_DISCONNECTED",
+          context: {
+            requestId,
+          },
+          recovery: "Reconnect the tunnel agent before retrying the tool call.",
+        }),
+      );
     }
   };
 
@@ -158,8 +174,8 @@ export function attachNetworkTunnelSocket(
         targetType: message.targetType,
         agentId: message.agentId,
         registrationId: registered.registrationId,
-        send: (toolCall) =>
-          sendToolCall(args.socket, pending, toolCall, timeoutMs),
+        send: (toolCall, options) =>
+          sendToolCall(args.socket, pending, toolCall, timeoutMs, options),
       });
       args.socket.send(JSON.stringify(agentReady(message)));
     } finally {
@@ -179,11 +195,17 @@ function isValidAgentHello(
     message.keyVersion > 0;
 }
 
+function hasSupportedProtocolVersion(message: NetworkMessage): boolean {
+  return "protocolVersion" in message &&
+    message.protocolVersion === NETWORK_PROTOCOL_VERSION;
+}
+
 function sendToolCall(
   socket: NetworkTunnelSocket,
   pending: Map<string, PendingToolCall>,
   toolCall: NetworkToolCallRequest,
   timeoutMs: number,
+  options?: RegisteredNetworkAgentSendOptions,
 ): Promise<NetworkToolCallResponse> {
   if (pending.has(toolCall.requestId)) {
     return Promise.reject(
@@ -192,22 +214,97 @@ function sendToolCall(
   }
 
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
+    const signal = options?.signal;
+    const abort = () => {
+      const waiter = pending.get(toolCall.requestId);
+      if (!waiter) return;
       pending.delete(toolCall.requestId);
+      cleanupPendingToolCall(waiter);
+      const error = relayErrorFromAbortSignal(signal, toolCall.requestId);
+      sendCancellationFrame(socket, toolCall.requestId, error);
+      reject(error);
+    };
+    const timer = setTimeout(() => {
+      const waiter = pending.get(toolCall.requestId);
+      pending.delete(toolCall.requestId);
+      if (waiter) cleanupPendingToolCall(waiter);
+      const error = new NetworkRelayError({
+        code: "TUNNEL_REQUEST_TIMEOUT",
+        context: { requestId: toolCall.requestId },
+        recovery: "Check the agent connection and retry the tool call.",
+      });
+      sendCancellationFrame(socket, toolCall.requestId, error);
       reject(
-        new Error(`TUNNEL_TOOL_CALL_TIMEOUT requestId=${toolCall.requestId}`),
+        error,
       );
     }, timeoutMs);
-    pending.set(toolCall.requestId, { resolve, reject, timer });
+    signal?.addEventListener("abort", abort, { once: true });
+    pending.set(toolCall.requestId, {
+      resolve,
+      reject,
+      timer,
+      signal,
+      onAbort: abort,
+    });
+
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
 
     try {
       socket.send(JSON.stringify(toolCall));
     } catch (err) {
       pending.delete(toolCall.requestId);
-      clearTimeout(timer);
+      cleanupPendingToolCall({
+        resolve,
+        reject,
+        timer,
+        signal,
+        onAbort: abort,
+      });
       reject(err instanceof Error ? err : new Error(String(err)));
     }
   });
+}
+
+function cleanupPendingToolCall(waiter: PendingToolCall): void {
+  clearTimeout(waiter.timer);
+  if (waiter.signal && waiter.onAbort) {
+    waiter.signal.removeEventListener("abort", waiter.onAbort);
+  }
+}
+
+function relayErrorFromAbortSignal(
+  signal: AbortSignal | undefined,
+  requestId: string,
+): NetworkRelayError {
+  const reason = signal?.reason;
+  if (reason instanceof NetworkRelayError) return reason;
+  return new NetworkRelayError({
+    code: "TUNNEL_REQUEST_CANCELLED",
+    context: { requestId },
+    recovery: "Retry after the tunnel agent is registered again.",
+  });
+}
+
+function sendCancellationFrame(
+  socket: NetworkTunnelSocket,
+  requestId: string,
+  error: NetworkRelayError,
+): void {
+  try {
+    socket.send(JSON.stringify({
+      type: "error",
+      requestId,
+      code: error.code,
+      message: error.message,
+      context: error.context,
+    }));
+  } catch {
+    // The abort may be caused by the same broken socket; the relay already has
+    // the structured rejection locally.
+  }
 }
 
 function parseNetworkMessage(raw: string): NetworkMessage | null {
@@ -232,6 +329,7 @@ function isNonEmptyString(value: unknown): value is string {
 function agentReady(message: NetworkAgentHello): NetworkMessage {
   return {
     type: "agent.ready",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: message.tenantId,
     targetType: message.targetType,
     agentId: message.agentId,

--- a/packages/bridge/src/adapters/network/socket-relay_test.ts
+++ b/packages/bridge/src/adapters/network/socket-relay_test.ts
@@ -1,8 +1,8 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import type { NetworkMessage } from "./types.ts";
-import { NetworkRelay } from "./relay.ts";
+import { NETWORK_PROTOCOL_VERSION, type NetworkMessage } from "./types.ts";
+import { NetworkRelay, NetworkRelayError } from "./relay.ts";
+import { allowInsecureNetworkAgentHelloForTests } from "./_test-fixtures.ts";
 import {
-  allowInsecureNetworkAgentHelloForTests,
   attachNetworkTunnelSocket,
   type NetworkTunnelSocket,
 } from "./socket-relay.ts";
@@ -40,6 +40,7 @@ Deno.test("attachNetworkTunnelSocket registers agent and routes tool calls", asy
 
   socket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_1",
     targetType: "erpnext",
     agentId: "agent_1",
@@ -49,6 +50,7 @@ Deno.test("attachNetworkTunnelSocket registers agent and routes tool calls", asy
 
   assertEquals(socket.sent.at(-1), {
     type: "agent.ready",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_1",
     targetType: "erpnext",
     agentId: "agent_1",
@@ -78,6 +80,167 @@ Deno.test("attachNetworkTunnelSocket registers agent and routes tool calls", asy
   assertEquals(await resultPromise, { ok: true });
 });
 
+Deno.test("attachNetworkTunnelSocket rejects in-flight calls when socket closes", async () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_disconnect",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  socket.receive({
+    type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
+    tenantId: "tenant_disconnect",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+
+  const call = relay.callTool({
+    tenantId: "tenant_disconnect",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  await Promise.resolve();
+
+  const toolCall = socket.sent.at(-1);
+  assertEquals(toolCall?.type, "tool.call");
+  const rejection = withTimeout(
+    assertRejects(
+      () => call,
+      NetworkRelayError,
+      "TUNNEL_AGENT_DISCONNECTED",
+    ),
+    "in-flight call was not rejected after socket close",
+  );
+
+  socket.close();
+
+  const error = await rejection;
+  assertEquals(error.code, "TUNNEL_AGENT_DISCONNECTED");
+  assertEquals(error.context.tenantId, "tenant_disconnect");
+  assertEquals(error.context.targetType, "erpnext");
+  assertEquals(error.context.agentId, "agent_1");
+});
+
+Deno.test("attachNetworkTunnelSocket sends cancellation frame when relay timeout aborts call", async () => {
+  const relay = new NetworkRelay({ requestTimeoutMs: 1 });
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_timeout_abort",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  socket.receive({
+    type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
+    tenantId: "tenant_timeout_abort",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+
+  const call = relay.callTool({
+    tenantId: "tenant_timeout_abort",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  await Promise.resolve();
+
+  const toolCall = socket.sent.at(-1);
+  assertEquals(toolCall?.type, "tool.call");
+  if (toolCall?.type !== "tool.call") {
+    throw new Error("expected tool.call");
+  }
+
+  try {
+    await assertRejects(
+      () => call,
+      NetworkRelayError,
+      "TUNNEL_REQUEST_TIMEOUT",
+    );
+
+    assertEquals(socket.sent.at(-1), {
+      type: "error",
+      requestId: toolCall.requestId,
+      code: "TUNNEL_REQUEST_TIMEOUT",
+      message:
+        "TUNNEL_REQUEST_TIMEOUT: Check the agent connection and retry the tool call.",
+      context: {
+        tenantId: "tenant_timeout_abort",
+        targetType: "erpnext",
+        requestId: toolCall.requestId,
+      },
+    });
+  } finally {
+    socket.close();
+  }
+});
+
+Deno.test("attachNetworkTunnelSocket rejects mismatched protocol version", () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_protocol_mismatch",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  socket.onmessage?.({
+    data: JSON.stringify({
+      type: "agent.hello",
+      protocolVersion: NETWORK_PROTOCOL_VERSION + 1,
+      tenantId: "tenant_protocol_mismatch",
+      targetType: "erpnext",
+      agentId: "agent_1",
+      keyVersion: 1,
+    }),
+  });
+
+  assertEquals(socket.closeCalls, [{
+    code: 4002,
+    reason: "protocol version mismatch",
+  }]);
+});
+
+Deno.test("attachNetworkTunnelSocket rejects missing protocol version", () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_protocol_missing",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  socket.onmessage?.({
+    data: JSON.stringify({
+      type: "agent.hello",
+      tenantId: "tenant_protocol_missing",
+      targetType: "erpnext",
+      agentId: "agent_1",
+      keyVersion: 1,
+    }),
+  });
+
+  assertEquals(socket.closeCalls, [{
+    code: 4002,
+    reason: "protocol version mismatch",
+  }]);
+});
+
 Deno.test("attachNetworkTunnelSocket rejects cross-tenant hello", async () => {
   const relay = new NetworkRelay();
   const socket = new FakeTunnelSocket();
@@ -89,6 +252,7 @@ Deno.test("attachNetworkTunnelSocket rejects cross-tenant hello", async () => {
 
   socket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "other_tenant",
     targetType: "erpnext",
     agentId: "agent_1",
@@ -125,6 +289,7 @@ Deno.test("attachNetworkTunnelSocket rejects malformed hello before registration
   socket.onmessage?.({
     data: JSON.stringify({
       type: "agent.hello",
+      protocolVersion: NETWORK_PROTOCOL_VERSION,
       tenantId: "tenant_route_bad",
     }),
   });
@@ -159,6 +324,7 @@ Deno.test("attachNetworkTunnelSocket rejects hello when no authorizer is configu
 
   socket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_no_auth",
     targetType: "erpnext",
     agentId: "agent_1",
@@ -198,6 +364,7 @@ Deno.test("attachNetworkTunnelSocket closes when hello authorizer throws", async
 
   socket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_auth_error",
     targetType: "erpnext",
     agentId: "agent_1",
@@ -230,6 +397,7 @@ Deno.test("attachNetworkTunnelSocket keeps replacement agent after stale close",
 
   oldSocket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_3",
     targetType: "erpnext",
     agentId: "agent_old",
@@ -238,6 +406,7 @@ Deno.test("attachNetworkTunnelSocket keeps replacement agent after stale close",
   await Promise.resolve();
   newSocket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_3",
     targetType: "erpnext",
     agentId: "agent_new",
@@ -289,6 +458,7 @@ Deno.test("attachNetworkTunnelSocket keeps reconnect with same agent id after st
 
   oldSocket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_reconnect",
     targetType: "erpnext",
     agentId: "agent_same",
@@ -297,6 +467,7 @@ Deno.test("attachNetworkTunnelSocket keeps reconnect with same agent id after st
   await Promise.resolve();
   newSocket.receive({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_route_reconnect",
     targetType: "erpnext",
     agentId: "agent_same",
@@ -347,3 +518,13 @@ Deno.test("attachNetworkTunnelSocket closes idle sockets that never send hello",
     reason: "agent hello timeout",
   }]);
 });
+
+function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: number | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), 20);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}

--- a/packages/bridge/src/adapters/network/socket-relay_test.ts
+++ b/packages/bridge/src/adapters/network/socket-relay_test.ts
@@ -1,0 +1,349 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type { NetworkMessage } from "./types.ts";
+import { NetworkRelay } from "./relay.ts";
+import {
+  allowInsecureNetworkAgentHelloForTests,
+  attachNetworkTunnelSocket,
+  type NetworkTunnelSocket,
+} from "./socket-relay.ts";
+
+class FakeTunnelSocket implements NetworkTunnelSocket {
+  sent: NetworkMessage[] = [];
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data) as NetworkMessage);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.onclose?.();
+  }
+
+  receive(message: NetworkMessage): void {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+}
+
+Deno.test("attachNetworkTunnelSocket registers agent and routes tool calls", async () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_route_1",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  socket.receive({
+    type: "agent.hello",
+    tenantId: "tenant_route_1",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+
+  assertEquals(socket.sent.at(-1), {
+    type: "agent.ready",
+    tenantId: "tenant_route_1",
+    targetType: "erpnext",
+    agentId: "agent_1",
+  });
+
+  const resultPromise = relay.callTool({
+    tenantId: "tenant_route_1",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: { limit: 1 },
+    actorSubject: "user_123",
+  });
+  await Promise.resolve();
+
+  const toolCall = socket.sent.at(-1);
+  assertEquals(toolCall?.type, "tool.call");
+  if (toolCall?.type !== "tool.call") {
+    throw new Error("expected tool.call");
+  }
+
+  socket.receive({
+    type: "tool.result",
+    requestId: toolCall.requestId,
+    result: { ok: true },
+  });
+
+  assertEquals(await resultPromise, { ok: true });
+});
+
+Deno.test("attachNetworkTunnelSocket rejects cross-tenant hello", async () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_route_2",
+  });
+
+  socket.receive({
+    type: "agent.hello",
+    tenantId: "other_tenant",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+
+  assertEquals(socket.closeCalls, [{
+    code: 4003,
+    reason: "tenant mismatch",
+  }]);
+  await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_route_2",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    Error,
+    "NO_TUNNEL_AGENT",
+  );
+});
+
+Deno.test("attachNetworkTunnelSocket rejects malformed hello before registration", async () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_route_bad",
+  });
+
+  socket.onmessage?.({
+    data: JSON.stringify({
+      type: "agent.hello",
+      tenantId: "tenant_route_bad",
+    }),
+  });
+  await Promise.resolve();
+
+  assertEquals(socket.closeCalls, [{
+    code: 4002,
+    reason: "invalid agent hello",
+  }]);
+  await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_route_bad",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    Error,
+    "NO_TUNNEL_AGENT",
+  );
+});
+
+Deno.test("attachNetworkTunnelSocket rejects hello when no authorizer is configured", async () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_route_no_auth",
+  });
+
+  socket.receive({
+    type: "agent.hello",
+    tenantId: "tenant_route_no_auth",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+
+  assertEquals(socket.closeCalls, [{
+    code: 4001,
+    reason: "agent authorization required",
+  }]);
+  await assertRejects(
+    () =>
+      relay.callTool({
+        tenantId: "tenant_route_no_auth",
+        targetType: "erpnext",
+        toolName: "erpnext.customer_list",
+        arguments: {},
+        actorSubject: null,
+      }),
+    Error,
+    "NO_TUNNEL_AGENT",
+  );
+});
+
+Deno.test("attachNetworkTunnelSocket closes when hello authorizer throws", async () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_route_auth_error",
+    authorizeAgentHello: () => {
+      throw new Error("authorizer offline");
+    },
+  });
+
+  socket.receive({
+    type: "agent.hello",
+    tenantId: "tenant_route_auth_error",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+
+  assertEquals(socket.closeCalls, [{
+    code: 4001,
+    reason: "agent authorization failed",
+  }]);
+});
+
+Deno.test("attachNetworkTunnelSocket keeps replacement agent after stale close", async () => {
+  const relay = new NetworkRelay();
+  const oldSocket = new FakeTunnelSocket();
+  const newSocket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket: oldSocket,
+    tenantId: "tenant_route_3",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+  attachNetworkTunnelSocket({
+    relay,
+    socket: newSocket,
+    tenantId: "tenant_route_3",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  oldSocket.receive({
+    type: "agent.hello",
+    tenantId: "tenant_route_3",
+    targetType: "erpnext",
+    agentId: "agent_old",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+  newSocket.receive({
+    type: "agent.hello",
+    tenantId: "tenant_route_3",
+    targetType: "erpnext",
+    agentId: "agent_new",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+
+  oldSocket.close();
+  const resultPromise = relay.callTool({
+    tenantId: "tenant_route_3",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  await Promise.resolve();
+
+  const toolCall = newSocket.sent.at(-1);
+  assertEquals(toolCall?.type, "tool.call");
+  if (toolCall?.type !== "tool.call") {
+    throw new Error("expected tool.call");
+  }
+
+  newSocket.receive({
+    type: "tool.result",
+    requestId: toolCall.requestId,
+    result: { agent: "new" },
+  });
+
+  assertEquals(await resultPromise, { agent: "new" });
+});
+
+Deno.test("attachNetworkTunnelSocket keeps reconnect with same agent id after stale close", async () => {
+  const relay = new NetworkRelay();
+  const oldSocket = new FakeTunnelSocket();
+  const newSocket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket: oldSocket,
+    tenantId: "tenant_route_reconnect",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+  attachNetworkTunnelSocket({
+    relay,
+    socket: newSocket,
+    tenantId: "tenant_route_reconnect",
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  oldSocket.receive({
+    type: "agent.hello",
+    tenantId: "tenant_route_reconnect",
+    targetType: "erpnext",
+    agentId: "agent_same",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+  newSocket.receive({
+    type: "agent.hello",
+    tenantId: "tenant_route_reconnect",
+    targetType: "erpnext",
+    agentId: "agent_same",
+    keyVersion: 1,
+  });
+  await Promise.resolve();
+
+  oldSocket.close();
+  const resultPromise = relay.callTool({
+    tenantId: "tenant_route_reconnect",
+    targetType: "erpnext",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  });
+  await Promise.resolve();
+
+  const toolCall = newSocket.sent.at(-1);
+  assertEquals(toolCall?.type, "tool.call");
+  if (toolCall?.type !== "tool.call") {
+    throw new Error("expected tool.call");
+  }
+
+  newSocket.receive({
+    type: "tool.result",
+    requestId: toolCall.requestId,
+    result: { agent: "new" },
+  });
+
+  assertEquals(await resultPromise, { agent: "new" });
+});
+
+Deno.test("attachNetworkTunnelSocket closes idle sockets that never send hello", async () => {
+  const relay = new NetworkRelay();
+  const socket = new FakeTunnelSocket();
+  attachNetworkTunnelSocket({
+    relay,
+    socket,
+    tenantId: "tenant_route_idle",
+    helloTimeoutMs: 1,
+    authorizeAgentHello: allowInsecureNetworkAgentHelloForTests,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+
+  assertEquals(socket.closeCalls, [{
+    code: 4002,
+    reason: "agent hello timeout",
+  }]);
+});

--- a/packages/bridge/src/adapters/network/types.ts
+++ b/packages/bridge/src/adapters/network/types.ts
@@ -6,6 +6,8 @@
  * MCP tool calls to that agent.
  */
 
+export const NETWORK_PROTOCOL_VERSION = 1;
+
 export type NetworkMessage =
   | NetworkAgentHello
   | NetworkAgentReady
@@ -16,6 +18,7 @@ export type NetworkMessage =
 
 export interface NetworkAgentHello {
   readonly type: "agent.hello";
+  readonly protocolVersion: number;
   readonly tenantId: string;
   readonly targetType: string;
   readonly agentId: string;
@@ -24,6 +27,7 @@ export interface NetworkAgentHello {
 
 export interface NetworkAgentReady {
   readonly type: "agent.ready";
+  readonly protocolVersion: number;
   readonly tenantId: string;
   readonly targetType: string;
   readonly agentId: string;

--- a/packages/bridge/src/adapters/network/types.ts
+++ b/packages/bridge/src/adapters/network/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Network tunnel message contract.
+ *
+ * This adapter is the outbound tunnel counterpart to Telegram/LINE bridges:
+ * a customer-side agent opens a WebSocket to a SaaS relay, then the relay routes
+ * MCP tool calls to that agent.
+ */
+
+export type NetworkMessage =
+  | NetworkAgentHello
+  | NetworkAgentReady
+  | NetworkHeartbeat
+  | NetworkToolCallRequest
+  | NetworkToolCallResponse
+  | NetworkError;
+
+export interface NetworkAgentHello {
+  readonly type: "agent.hello";
+  readonly tenantId: string;
+  readonly targetType: string;
+  readonly agentId: string;
+  readonly keyVersion: number;
+}
+
+export interface NetworkAgentReady {
+  readonly type: "agent.ready";
+  readonly tenantId: string;
+  readonly targetType: string;
+  readonly agentId: string;
+}
+
+export interface NetworkHeartbeat {
+  readonly type: "heartbeat";
+  readonly at: string;
+}
+
+export interface NetworkToolCallRequest {
+  readonly type: "tool.call";
+  readonly requestId: string;
+  readonly toolName: string;
+  readonly arguments: Record<string, unknown>;
+  readonly actorSubject: string | null;
+}
+
+export interface NetworkToolCallResponse {
+  readonly type: "tool.result";
+  readonly requestId: string;
+  readonly result: unknown;
+}
+
+export interface NetworkError {
+  readonly type: "error";
+  readonly requestId?: string;
+  readonly code: string;
+  readonly message: string;
+  readonly context: Record<string, unknown>;
+}

--- a/packages/bridge/src/adapters/network/types_test.ts
+++ b/packages/bridge/src/adapters/network/types_test.ts
@@ -1,9 +1,15 @@
 import { assertEquals } from "@std/assert";
-import type { NetworkAgentHello, NetworkToolCallRequest } from "./types.ts";
+import {
+  NETWORK_PROTOCOL_VERSION,
+  type NetworkAgentHello,
+  type NetworkAgentReady,
+  type NetworkToolCallRequest,
+} from "./types.ts";
 
 Deno.test("network tunnel type examples stay stable", () => {
   const hello: NetworkAgentHello = {
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_123",
     targetType: "erpnext",
     agentId: "agent_local_1",
@@ -16,7 +22,15 @@ Deno.test("network tunnel type examples stay stable", () => {
     arguments: { limit: 10 },
     actorSubject: "user_123",
   };
+  const ready: NetworkAgentReady = {
+    type: "agent.ready",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_local_1",
+  };
 
   assertEquals(hello.type, "agent.hello");
+  assertEquals(ready.protocolVersion, NETWORK_PROTOCOL_VERSION);
   assertEquals(call.toolName, "erpnext.customer_list");
 });

--- a/packages/bridge/src/adapters/network/types_test.ts
+++ b/packages/bridge/src/adapters/network/types_test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "@std/assert";
+import type { NetworkAgentHello, NetworkToolCallRequest } from "./types.ts";
+
+Deno.test("network tunnel type examples stay stable", () => {
+  const hello: NetworkAgentHello = {
+    type: "agent.hello",
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_local_1",
+    keyVersion: 1,
+  };
+  const call: NetworkToolCallRequest = {
+    type: "tool.call",
+    requestId: "req_1",
+    toolName: "erpnext.customer_list",
+    arguments: { limit: 10 },
+    actorSubject: "user_123",
+  };
+
+  assertEquals(hello.type, "agent.hello");
+  assertEquals(call.toolName, "erpnext.customer_list");
+});

--- a/packages/bridge/src/adapters/network/websocket-transport.ts
+++ b/packages/bridge/src/adapters/network/websocket-transport.ts
@@ -1,0 +1,273 @@
+import type { NetworkMessage } from "./types.ts";
+import type { NetworkTunnelTransport } from "./client.ts";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface NetworkWebSocketLike {
+  readonly readyState: number;
+  send(data: string): void;
+  close(): void;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+  onerror: (() => void) | null;
+  onclose: (() => void) | null;
+}
+
+export interface NetworkWebSocketFactoryOptions {
+  readonly protocols?: string | string[];
+  readonly headers?: Record<string, string>;
+}
+
+export type NetworkWebSocketFactory = (
+  url: string,
+  options?: NetworkWebSocketFactoryOptions,
+) => NetworkWebSocketLike;
+
+export type NetworkTransportAuth =
+  | {
+    readonly type: "bearer";
+    readonly token: string | (() => MaybePromise<string>);
+    readonly via?: "header" | "query";
+    readonly queryParam?: string;
+  }
+  | {
+    readonly type: "headers";
+    readonly headers:
+      | Record<string, string>
+      | (() => MaybePromise<Record<string, string>>);
+  };
+
+export interface WebSocketNetworkTransportOptions {
+  readonly webSocketFactory?: NetworkWebSocketFactory;
+  readonly auth?: NetworkTransportAuth;
+  readonly protocols?: string | string[];
+}
+
+export class WebSocketNetworkTransport implements NetworkTunnelTransport {
+  private readonly webSocketFactory: NetworkWebSocketFactory;
+  private readonly auth: NetworkTransportAuth | undefined;
+  private readonly protocols: string | string[] | undefined;
+  private socket: NetworkWebSocketLike | null = null;
+  private readonly messageHandlers: Array<(message: NetworkMessage) => void> =
+    [];
+
+  constructor(options: WebSocketNetworkTransportOptions = {}) {
+    this.auth = options.auth;
+    this.protocols = options.protocols;
+    this.webSocketFactory = options.webSocketFactory ?? ((url, init) => {
+      const WebSocketCtor = WebSocket as unknown as NativeWebSocketConstructor;
+      return new WebSocketCtor(
+        url,
+        toNativeWebSocketOptions(init),
+      ) as unknown as NetworkWebSocketLike;
+    });
+  }
+
+  connect(url: string): Promise<void> {
+    let connection: WebSocketConnection | Promise<WebSocketConnection>;
+    try {
+      connection = buildConnection(url, this.auth, this.protocols);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    if (isPromiseLike(connection)) {
+      return connection.then((resolved) => this.open(resolved));
+    }
+    return this.open(connection);
+  }
+
+  private open(connection: WebSocketConnection): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const socket = this.webSocketFactory(
+        connection.url,
+        connection.options,
+      );
+      let connected = false;
+      socket.onopen = () => {
+        connected = true;
+        this.socket = socket;
+        resolve();
+      };
+      socket.onerror = () => {
+        reject(
+          new Error(
+            `WebSocket network tunnel failed to connect: ${connection.url}`,
+          ),
+        );
+      };
+      socket.onmessage = (event) => {
+        this.receive(event.data);
+      };
+      socket.onclose = () => {
+        if (!connected) {
+          reject(
+            new Error(
+              `WebSocket network tunnel closed before it connected: ${connection.url}`,
+            ),
+          );
+        }
+        if (this.socket === socket) this.socket = null;
+      };
+    });
+  }
+
+  send(message: NetworkMessage): void {
+    if (!this.socket || this.socket.readyState !== 1) {
+      throw new Error("WebSocket network tunnel is not connected");
+    }
+    this.socket.send(JSON.stringify(message));
+  }
+
+  onMessage(handler: (message: NetworkMessage) => void): void {
+    this.messageHandlers.push(handler);
+  }
+
+  disconnect(): void {
+    this.socket?.close();
+    this.socket = null;
+  }
+
+  private receive(raw: string): void {
+    try {
+      const message = JSON.parse(raw) as NetworkMessage;
+      for (const handler of this.messageHandlers) {
+        handler(message);
+      }
+    } catch {
+      // Invalid JSON from the relay is ignored at transport level. The protocol
+      // layer can add strict validation once the handshake schema is final.
+    }
+  }
+}
+
+interface WebSocketConnection {
+  readonly url: string;
+  readonly options?: NetworkWebSocketFactoryOptions;
+}
+
+function buildConnection(
+  url: string,
+  auth: NetworkTransportAuth | undefined,
+  protocols: string | string[] | undefined,
+): WebSocketConnection | Promise<WebSocketConnection> {
+  if (!auth) {
+    return protocols ? { url, options: { protocols } } : { url };
+  }
+
+  if (auth.type === "bearer") {
+    const token = resolveAuthValue(auth.token);
+    return isPromiseLike(token)
+      ? token.then((resolved) =>
+        bearerConnection(url, protocols, auth, resolved)
+      )
+      : bearerConnection(url, protocols, auth, token);
+  }
+
+  const headers = resolveHeaders(auth.headers);
+  return isPromiseLike(headers)
+    ? headers.then((resolved) => ({
+      url,
+      options: withHeaders(protocols, resolved),
+    }))
+    : { url, options: withHeaders(protocols, headers) };
+}
+
+function bearerConnection(
+  url: string,
+  protocols: string | string[] | undefined,
+  auth: Extract<NetworkTransportAuth, { type: "bearer" }>,
+  token: string,
+): WebSocketConnection {
+  if (auth.via === "query") {
+    const queryUrl = new URL(url);
+    queryUrl.searchParams.set(auth.queryParam ?? "access_token", token);
+    return protocols
+      ? { url: queryUrl.toString(), options: { protocols } }
+      : { url: queryUrl.toString() };
+  }
+
+  return {
+    url,
+    options: withHeaders(protocols, {
+      authorization: `Bearer ${token}`,
+    }),
+  };
+}
+
+function withHeaders(
+  protocols: string | string[] | undefined,
+  headers: Record<string, string>,
+): NetworkWebSocketFactoryOptions {
+  return protocols ? { protocols, headers } : { headers };
+}
+
+function resolveHeaders(
+  headers:
+    | Record<string, string>
+    | (() => MaybePromise<Record<string, string>>),
+): Record<string, string> | Promise<Record<string, string>> {
+  const resolved = typeof headers === "function" ? headers() : headers;
+  if (isPromiseLike(resolved)) {
+    return resolved.then(normalizeHeaders);
+  }
+  return normalizeHeaders(resolved);
+}
+
+function normalizeHeaders(
+  resolved: Record<string, string>,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(resolved)) {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      throw new Error("WebSocket network tunnel auth header name is empty");
+    }
+    normalized[trimmedName.toLowerCase()] = validateAuthValue(
+      value,
+      `auth header ${trimmedName}`,
+    );
+  }
+  return normalized;
+}
+
+function resolveAuthValue(
+  value: string | (() => MaybePromise<string>),
+): string | Promise<string> {
+  const resolved = typeof value === "function" ? value() : value;
+  return isPromiseLike(resolved)
+    ? resolved.then((token) => validateAuthValue(token, "auth token"))
+    : validateAuthValue(resolved, "auth token");
+}
+
+function validateAuthValue(value: string, label: string): string {
+  if (value.trim().length === 0) {
+    throw new Error(`WebSocket network tunnel ${label} is empty`);
+  }
+  return value;
+}
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as { then?: unknown }).then === "function";
+}
+
+function toNativeWebSocketOptions(
+  options: NetworkWebSocketFactoryOptions | undefined,
+): string | string[] | NativeWebSocketOptions | undefined {
+  if (!options) return undefined;
+  if (options.headers) {
+    return { protocols: options.protocols, headers: options.headers };
+  }
+  return options.protocols;
+}
+
+interface NativeWebSocketOptions {
+  readonly protocols?: string | string[];
+  readonly headers?: Record<string, string>;
+}
+
+interface NativeWebSocketConstructor {
+  new (
+    url: string,
+    protocolsOrOptions?: string | string[] | NativeWebSocketOptions,
+  ): WebSocket;
+}

--- a/packages/bridge/src/adapters/network/websocket-transport.ts
+++ b/packages/bridge/src/adapters/network/websocket-transport.ts
@@ -1,5 +1,8 @@
 import type { NetworkMessage } from "./types.ts";
-import type { NetworkTunnelTransport } from "./client.ts";
+import type {
+  NetworkTunnelCloseReason,
+  NetworkTunnelTransport,
+} from "./client.ts";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -9,8 +12,10 @@ export interface NetworkWebSocketLike {
   close(): void;
   onopen: (() => void) | null;
   onmessage: ((event: { data: string }) => void) | null;
-  onerror: (() => void) | null;
-  onclose: (() => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onclose:
+    | ((event?: { code?: number; reason?: string }) => void)
+    | null;
 }
 
 export interface NetworkWebSocketFactoryOptions {
@@ -50,6 +55,11 @@ export class WebSocketNetworkTransport implements NetworkTunnelTransport {
   private socket: NetworkWebSocketLike | null = null;
   private readonly messageHandlers: Array<(message: NetworkMessage) => void> =
     [];
+  private readonly openHandlers: Array<() => void> = [];
+  private readonly closeHandlers: Array<
+    (reason: NetworkTunnelCloseReason) => void
+  > = [];
+  private readonly errorHandlers: Array<(error: unknown) => void> = [];
 
   constructor(options: WebSocketNetworkTransportOptions = {}) {
     this.auth = options.auth;
@@ -78,6 +88,10 @@ export class WebSocketNetworkTransport implements NetworkTunnelTransport {
 
   private open(connection: WebSocketConnection): Promise<void> {
     return new Promise((resolve, reject) => {
+      const redactedUrl = redactUrl(
+        connection.url,
+        authQueryParam(this.auth),
+      );
       const socket = this.webSocketFactory(
         connection.url,
         connection.options,
@@ -86,27 +100,34 @@ export class WebSocketNetworkTransport implements NetworkTunnelTransport {
       socket.onopen = () => {
         connected = true;
         this.socket = socket;
+        this.emitOpen();
         resolve();
       };
-      socket.onerror = () => {
-        reject(
-          new Error(
-            `WebSocket network tunnel failed to connect: ${connection.url}`,
-          ),
+      socket.onerror = (event) => {
+        const error = new Error(
+          `WebSocket network tunnel failed to connect: ${redactedUrl}`,
         );
+        this.emitError(event ?? error);
+        if (!connected) {
+          reject(error);
+        }
       };
       socket.onmessage = (event) => {
         this.receive(event.data);
       };
-      socket.onclose = () => {
+      socket.onclose = (event) => {
         if (!connected) {
           reject(
             new Error(
-              `WebSocket network tunnel closed before it connected: ${connection.url}`,
+              `WebSocket network tunnel closed before it connected: ${redactedUrl}`,
             ),
           );
         }
         if (this.socket === socket) this.socket = null;
+        this.emitClose({
+          code: event?.code,
+          reason: event?.reason,
+        });
       };
     });
   }
@@ -120,6 +141,18 @@ export class WebSocketNetworkTransport implements NetworkTunnelTransport {
 
   onMessage(handler: (message: NetworkMessage) => void): void {
     this.messageHandlers.push(handler);
+  }
+
+  onOpen(handler: () => void): void {
+    this.openHandlers.push(handler);
+  }
+
+  onClose(handler: (reason: NetworkTunnelCloseReason) => void): void {
+    this.closeHandlers.push(handler);
+  }
+
+  onError(handler: (error: unknown) => void): void {
+    this.errorHandlers.push(handler);
   }
 
   disconnect(): void {
@@ -138,11 +171,62 @@ export class WebSocketNetworkTransport implements NetworkTunnelTransport {
       // layer can add strict validation once the handshake schema is final.
     }
   }
+
+  private emitOpen(): void {
+    for (const handler of this.openHandlers) handler();
+  }
+
+  private emitClose(reason: NetworkTunnelCloseReason): void {
+    for (const handler of this.closeHandlers) handler(reason);
+  }
+
+  private emitError(error: unknown): void {
+    for (const handler of this.errorHandlers) handler(error);
+  }
 }
 
 interface WebSocketConnection {
   readonly url: string;
   readonly options?: NetworkWebSocketFactoryOptions;
+}
+
+function redactUrl(url: string, queryParam?: string): string {
+  const sensitiveParams = new Set(["access_token", "token"]);
+  const normalizedQueryParam = queryParam?.trim().toLowerCase();
+  if (normalizedQueryParam) {
+    sensitiveParams.add(normalizedQueryParam);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  const paramsToRedact = new Set<string>();
+  for (const [name] of parsed.searchParams) {
+    if (sensitiveParams.has(name.toLowerCase())) {
+      paramsToRedact.add(name);
+    }
+  }
+  if (paramsToRedact.size === 0) {
+    return url;
+  }
+
+  // Keep the endpoint identifiable while replacing bearer token values.
+  for (const name of paramsToRedact) {
+    parsed.searchParams.set(name, "***");
+  }
+  return parsed.toString();
+}
+
+function authQueryParam(
+  auth: NetworkTransportAuth | undefined,
+): string | undefined {
+  return auth?.type === "bearer" && auth.via === "query"
+    ? auth.queryParam
+    : undefined;
 }
 
 function buildConnection(

--- a/packages/bridge/src/adapters/network/websocket-transport_test.ts
+++ b/packages/bridge/src/adapters/network/websocket-transport_test.ts
@@ -1,0 +1,281 @@
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
+import {
+  type NetworkWebSocketFactoryOptions,
+  WebSocketNetworkTransport,
+} from "./websocket-transport.ts";
+import type { NetworkMessage } from "./types.ts";
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  readyState = FakeWebSocket.OPEN;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(readonly url: string) {}
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+}
+
+Deno.test("websocket network transport connects and sends JSON messages", async () => {
+  const sockets: FakeWebSocket[] = [];
+  const transport = new WebSocketNetworkTransport({
+    webSocketFactory: (url) => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+  const connected = transport.connect("wss://relay.example.test/mcp/_tunnel");
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onopen?.();
+  await connected;
+
+  transport.send({
+    type: "agent.hello",
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+
+  assertEquals(socket?.url, "wss://relay.example.test/mcp/_tunnel");
+  assertEquals(JSON.parse(socket?.sent[0] ?? ""), {
+    type: "agent.hello",
+    tenantId: "tenant_123",
+    targetType: "erpnext",
+    agentId: "agent_1",
+    keyVersion: 1,
+  });
+});
+
+Deno.test("websocket network transport sends bearer auth in handshake headers", async () => {
+  const sockets: FakeWebSocket[] = [];
+  let handshakeOptions: NetworkWebSocketFactoryOptions | undefined;
+  const transport = new WebSocketNetworkTransport({
+    auth: { type: "bearer", token: "oauth-access-token" },
+    webSocketFactory: (url, options) => {
+      handshakeOptions = options;
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect("wss://relay.example.test/mcp/_tunnel");
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onopen?.();
+  await connected;
+
+  assertEquals(socket.url, "wss://relay.example.test/mcp/_tunnel");
+  assertEquals(handshakeOptions, {
+    headers: { authorization: "Bearer oauth-access-token" },
+  });
+});
+
+Deno.test("websocket network transport sends custom auth headers", async () => {
+  const sockets: FakeWebSocket[] = [];
+  let handshakeOptions: NetworkWebSocketFactoryOptions | undefined;
+  const transport = new WebSocketNetworkTransport({
+    auth: {
+      type: "headers",
+      headers: {
+        authorization: "Bearer oauth-access-token",
+        "x-agent-id": "agent_1",
+      },
+    },
+    webSocketFactory: (url, options) => {
+      handshakeOptions = options;
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect("wss://relay.example.test/mcp/_tunnel");
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onopen?.();
+  await connected;
+
+  assertEquals(handshakeOptions, {
+    headers: {
+      authorization: "Bearer oauth-access-token",
+      "x-agent-id": "agent_1",
+    },
+  });
+});
+
+Deno.test("websocket network transport resolves async auth once per connection", async () => {
+  const sockets: FakeWebSocket[] = [];
+  let calls = 0;
+  let handshakeOptions: NetworkWebSocketFactoryOptions | undefined;
+  const transport = new WebSocketNetworkTransport({
+    auth: {
+      type: "bearer",
+      token: () => {
+        calls++;
+        return Promise.resolve("fresh-oauth-token");
+      },
+    },
+    webSocketFactory: (url, options) => {
+      handshakeOptions = options;
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect("wss://relay.example.test/mcp/_tunnel");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onopen?.();
+  await connected;
+
+  assertEquals(calls, 1);
+  assertEquals(handshakeOptions, {
+    headers: { authorization: "Bearer fresh-oauth-token" },
+  });
+});
+
+Deno.test("websocket network transport can put auth in the URL explicitly", async () => {
+  const sockets: FakeWebSocket[] = [];
+  let handshakeOptions: NetworkWebSocketFactoryOptions | undefined;
+  const transport = new WebSocketNetworkTransport({
+    auth: {
+      type: "bearer",
+      token: "oauth token",
+      via: "query",
+      queryParam: "access_token",
+    },
+    webSocketFactory: (url, options) => {
+      handshakeOptions = options;
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect(
+    "wss://relay.example.test/mcp/_tunnel?tenant=acme",
+  );
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onopen?.();
+  await connected;
+
+  assertEquals(
+    socket.url,
+    "wss://relay.example.test/mcp/_tunnel?tenant=acme&access_token=oauth+token",
+  );
+  assertEquals(handshakeOptions, undefined);
+});
+
+Deno.test("websocket network transport rejects empty bearer tokens before opening a socket", async () => {
+  let opened = false;
+  const transport = new WebSocketNetworkTransport({
+    auth: { type: "bearer", token: " " },
+    webSocketFactory: (url) => {
+      opened = true;
+      return new FakeWebSocket(url);
+    },
+  });
+
+  await assertRejects(
+    () => transport.connect("wss://relay.example.test/mcp/_tunnel"),
+    Error,
+    "auth token",
+  );
+  assertEquals(opened, false);
+});
+
+Deno.test("websocket network transport receives JSON messages", async () => {
+  const sockets: FakeWebSocket[] = [];
+  const received: NetworkMessage[] = [];
+  const transport = new WebSocketNetworkTransport({
+    webSocketFactory: (url) => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+  transport.onMessage((message) => received.push(message));
+  const connected = transport.connect("wss://relay.example.test/mcp/_tunnel");
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onopen?.();
+  await connected;
+
+  socket.onmessage?.({
+    data: JSON.stringify({
+      type: "tool.call",
+      requestId: "req_1",
+      toolName: "erpnext.customer_list",
+      arguments: {},
+      actorSubject: null,
+    }),
+  });
+
+  assertEquals(received, [{
+    type: "tool.call",
+    requestId: "req_1",
+    toolName: "erpnext.customer_list",
+    arguments: {},
+    actorSubject: null,
+  }]);
+});
+
+Deno.test("websocket network transport rejects send before connect", () => {
+  const transport = new WebSocketNetworkTransport({
+    webSocketFactory: (url) => new FakeWebSocket(url),
+  });
+
+  assertThrows(
+    () =>
+      transport.send({
+        type: "heartbeat",
+        at: "2026-05-15T00:00:00.000Z",
+      }),
+    Error,
+    "not connected",
+  );
+});
+
+Deno.test("websocket network transport rejects close before open", async () => {
+  const sockets: FakeWebSocket[] = [];
+  const transport = new WebSocketNetworkTransport({
+    webSocketFactory: (url) => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect("wss://relay.example.test/mcp/_tunnel");
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onclose?.();
+
+  await assertRejects(
+    () => connected,
+    Error,
+    "closed before it connected",
+  );
+});

--- a/packages/bridge/src/adapters/network/websocket-transport_test.ts
+++ b/packages/bridge/src/adapters/network/websocket-transport_test.ts
@@ -2,13 +2,14 @@ import {
   assertEquals,
   assertExists,
   assertRejects,
+  assertStringIncludes,
   assertThrows,
 } from "@std/assert";
 import {
   type NetworkWebSocketFactoryOptions,
   WebSocketNetworkTransport,
 } from "./websocket-transport.ts";
-import type { NetworkMessage } from "./types.ts";
+import { NETWORK_PROTOCOL_VERSION, type NetworkMessage } from "./types.ts";
 
 class FakeWebSocket {
   static readonly OPEN = 1;
@@ -48,6 +49,7 @@ Deno.test("websocket network transport connects and sends JSON messages", async 
 
   transport.send({
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_123",
     targetType: "erpnext",
     agentId: "agent_1",
@@ -57,6 +59,7 @@ Deno.test("websocket network transport connects and sends JSON messages", async 
   assertEquals(socket?.url, "wss://relay.example.test/mcp/_tunnel");
   assertEquals(JSON.parse(socket?.sent[0] ?? ""), {
     type: "agent.hello",
+    protocolVersion: NETWORK_PROTOCOL_VERSION,
     tenantId: "tenant_123",
     targetType: "erpnext",
     agentId: "agent_1",
@@ -277,5 +280,89 @@ Deno.test("websocket network transport rejects close before open", async () => {
     () => connected,
     Error,
     "closed before it connected",
+  );
+});
+
+Deno.test("websocket network transport redacts default query bearer token from connect errors", async () => {
+  const sockets: FakeWebSocket[] = [];
+  const transport = new WebSocketNetworkTransport({
+    auth: {
+      type: "bearer",
+      token: "secret tunnel token",
+      via: "query",
+    },
+    webSocketFactory: (url) => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect(
+    "wss://relay.example.test/mcp/_tunnel?tenant=acme",
+  );
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onerror?.();
+
+  const error = await assertRejects(() => connected, Error);
+  assertStringIncludes(error.message, "access_token=***");
+  assertEquals(error.message.includes("secret"), false);
+});
+
+Deno.test("websocket network transport redacts custom query bearer token from connect errors", async () => {
+  const sockets: FakeWebSocket[] = [];
+  const transport = new WebSocketNetworkTransport({
+    auth: {
+      type: "bearer",
+      token: "custom tunnel token",
+      via: "query",
+      queryParam: "relay_token",
+    },
+    webSocketFactory: (url) => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect(
+    "wss://relay.example.test/mcp/_tunnel?tenant=acme",
+  );
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onerror?.();
+
+  const error = await assertRejects(() => connected, Error);
+  assertStringIncludes(error.message, "relay_token=***");
+  assertEquals(error.message.includes("custom"), false);
+});
+
+Deno.test("websocket network transport leaves header-auth error URLs unchanged", async () => {
+  const sockets: FakeWebSocket[] = [];
+  const url =
+    "wss://relay.example.test/mcp/_tunnel?tenant=acme&tokenizer=keep&access_token_hint=public";
+  const transport = new WebSocketNetworkTransport({
+    auth: {
+      type: "bearer",
+      token: "header tunnel token",
+      via: "header",
+    },
+    webSocketFactory: (url) => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket;
+    },
+  });
+
+  const connected = transport.connect(url);
+  const socket = sockets[0];
+  assertExists(socket);
+  socket.onerror?.();
+
+  const error = await assertRejects(() => connected, Error);
+  assertStringIncludes(
+    error.message,
+    `WebSocket network tunnel failed to connect: ${url}`,
   );
 });

--- a/packages/bridge/src/core/bridge-client.ts
+++ b/packages/bridge/src/core/bridge-client.ts
@@ -61,9 +61,12 @@ export class BridgeClient {
   private hostContext: HostContext | null = null;
   private started = false;
 
-  // deno-lint-ignore no-explicit-any
   private originalPostMessage:
-    | ((message: any, targetOrigin: string, transfer?: Transferable[]) => void)
+    | ((
+      message: unknown,
+      targetOrigin: string,
+      transfer?: Transferable[],
+    ) => void)
     | null = null;
 
   constructor(options: BridgeClientOptions) {

--- a/packages/bridge/src/mod.ts
+++ b/packages/bridge/src/mod.ts
@@ -109,6 +109,42 @@ export { getTelegramWebApp } from "./adapters/telegram/sdk-bridge.ts";
 export { LineAdapter } from "./adapters/line/adapter.ts";
 export type { LiffSdk, LineAdapterConfig } from "./adapters/line/types.ts";
 
+// Adapters — Network tunnel
+export {
+  allowInsecureNetworkAgentHelloForTests,
+  attachNetworkTunnelSocket,
+  NetworkRelay,
+  NetworkRelayError,
+  NetworkTunnelClient,
+  WebSocketNetworkTransport,
+} from "./adapters/network/mod.ts";
+export type {
+  AttachNetworkTunnelSocketArgs,
+  NetworkAgentHello,
+  NetworkAgentHelloAuthorization,
+  NetworkAgentHelloAuthorizer,
+  NetworkAgentReady,
+  NetworkError,
+  NetworkHeartbeat,
+  NetworkMessage,
+  NetworkRelayConcurrencyStrategy,
+  NetworkRelayErrorCode,
+  NetworkRelayOptions,
+  NetworkToolCallHandler,
+  NetworkToolCallRequest,
+  NetworkToolCallResponse,
+  NetworkTransportAuth,
+  NetworkTunnelClientOptions,
+  NetworkTunnelSocket,
+  NetworkTunnelTransport,
+  NetworkWebSocketFactory,
+  NetworkWebSocketFactoryOptions,
+  NetworkWebSocketLike,
+  RegisteredNetworkAgent,
+  RelayToolCall,
+  WebSocketNetworkTransportOptions,
+} from "./adapters/network/mod.ts";
+
 // Resource server
 export { buildCspHeader } from "./resource-server/csp.ts";
 export type { CspOptions } from "./resource-server/csp.ts";

--- a/packages/bridge/src/mod.ts
+++ b/packages/bridge/src/mod.ts
@@ -111,8 +111,8 @@ export type { LiffSdk, LineAdapterConfig } from "./adapters/line/types.ts";
 
 // Adapters — Network tunnel
 export {
-  allowInsecureNetworkAgentHelloForTests,
   attachNetworkTunnelSocket,
+  NETWORK_PROTOCOL_VERSION,
   NetworkRelay,
   NetworkRelayError,
   NetworkTunnelClient,
@@ -131,16 +131,20 @@ export type {
   NetworkRelayErrorCode,
   NetworkRelayOptions,
   NetworkToolCallHandler,
+  NetworkToolCallHandlerOptions,
   NetworkToolCallRequest,
   NetworkToolCallResponse,
   NetworkTransportAuth,
   NetworkTunnelClientOptions,
+  NetworkTunnelCloseReason,
+  NetworkTunnelReconnectOptions,
   NetworkTunnelSocket,
   NetworkTunnelTransport,
   NetworkWebSocketFactory,
   NetworkWebSocketFactoryOptions,
   NetworkWebSocketLike,
   RegisteredNetworkAgent,
+  RegisteredNetworkAgentSendOptions,
   RelayToolCall,
   WebSocketNetworkTransportOptions,
 } from "./adapters/network/mod.ts";

--- a/packages/server/mod.ts
+++ b/packages/server/mod.ts
@@ -92,6 +92,7 @@ export type {
   ToolAnnotations,
   ToolErrorMapper,
   ToolHandler,
+  ToolHandlerContext,
 } from "./src/types.ts";
 
 /**

--- a/packages/server/src/auth/auth_test.ts
+++ b/packages/server/src/auth/auth_test.ts
@@ -212,9 +212,11 @@ Deno.test("createAuthMiddleware - throws AuthError on invalid token", async () =
 });
 
 Deno.test("createAuthMiddleware - injects frozen authInfo on valid token", async () => {
+  const claims = { nested: { flag: true } };
   const provider = new MockAuthProvider({
     subject: "user-1",
     scopes: ["read", "write"],
+    claims,
   });
   const middleware = createAuthMiddleware(provider);
   const ctx: MiddlewareContext = {
@@ -231,6 +233,10 @@ Deno.test("createAuthMiddleware - injects frozen authInfo on valid token", async
   assertEquals(authInfo.subject, "user-1");
   assertEquals(authInfo.scopes, ["read", "write"]);
   assert(Object.isFrozen(ctx.authInfo));
+  assert(Object.isFrozen(authInfo.scopes));
+  assert(Object.isFrozen(authInfo.claims));
+  assert(Object.isFrozen(authInfo.claims?.nested));
+  assertEquals(Object.isFrozen(claims), false);
 });
 
 // ============================================
@@ -414,6 +420,76 @@ Deno.test("HTTP + Auth - 200 with valid token", async () => {
     assertEquals(data.jsonrpc, "2.0");
     const result = JSON.parse(data.result.content[0].text);
     assertEquals(result.hello, "world");
+  } finally {
+    await http.shutdown();
+  }
+});
+
+Deno.test("HTTP + Auth - passes frozen authInfo to tool handler context", async () => {
+  const seen: Array<{
+    subject?: string;
+    scopes?: string[];
+    frozen: boolean;
+    scopesFrozen: boolean;
+  }> = [];
+  const server = new McpApp({
+    name: "test-auth-context",
+    version: "1.0.0",
+    logger: () => {},
+    auth: {
+      provider: new MockAuthProvider({
+        subject: "user-42",
+        scopes: ["read"],
+      }),
+    },
+  });
+
+  server.registerTool(
+    {
+      name: "context_echo",
+      description: "Echo handler auth context",
+      inputSchema: { type: "object" },
+    },
+    (_args, ctx) => {
+      seen.push({
+        subject: ctx?.authInfo?.subject,
+        scopes: ctx?.authInfo?.scopes,
+        frozen: Object.isFrozen(ctx?.authInfo),
+        scopesFrozen: Object.isFrozen(ctx?.authInfo?.scopes),
+      });
+      return { ok: true };
+    },
+  );
+
+  const listener = Deno.listen({ port: 0 });
+  const port = (listener.addr as Deno.NetAddr).port;
+  listener.close();
+
+  const http = await server.startHttp({ port, onListen: () => {} });
+
+  try {
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer valid-token",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "context_echo", arguments: {} },
+      }),
+    });
+
+    assertEquals(res.status, 200);
+    await res.json();
+    assertEquals(seen, [{
+      subject: "user-42",
+      scopes: ["read"],
+      frozen: true,
+      scopesFrozen: true,
+    }]);
   } finally {
     await http.shutdown();
   }

--- a/packages/server/src/auth/middleware.ts
+++ b/packages/server/src/auth/middleware.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AuthProvider } from "./provider.ts";
+import type { AuthInfo } from "./types.ts";
 import type { Middleware } from "../middleware/types.ts";
 import { isOtelEnabled, recordAuthEvent } from "../observability/otel.ts";
 
@@ -105,6 +106,32 @@ export function createForbiddenResponse(requiredScopes: string[]): Response {
   );
 }
 
+export function freezeAuthInfo(authInfo: AuthInfo): AuthInfo {
+  const scopes = Object.freeze([...authInfo.scopes]) as unknown as string[];
+  const frozen: AuthInfo = {
+    ...authInfo,
+    scopes,
+    ...(authInfo.claims
+      ? {
+        claims: deepFreezeJson(structuredClone(authInfo.claims)) as Record<
+          string,
+          unknown
+        >,
+      }
+      : {}),
+  };
+
+  return Object.freeze(frozen);
+}
+
+function deepFreezeJson<T>(value: T): T {
+  if (typeof value !== "object" || value === null) return value;
+  for (const nested of Object.values(value)) {
+    deepFreezeJson(nested);
+  }
+  return Object.freeze(value);
+}
+
 /**
  * Create an authentication middleware for the MCP pipeline.
  *
@@ -165,9 +192,7 @@ export function createAuthMiddleware(provider: AuthProvider): Middleware {
     }
 
     // Deep-freeze authInfo to prevent mutation by downstream middlewares
-    if (authInfo.claims) Object.freeze(authInfo.claims);
-    if (authInfo.scopes) Object.freeze(authInfo.scopes);
-    ctx.authInfo = Object.freeze(authInfo);
+    ctx.authInfo = freezeAuthInfo(authInfo);
 
     // Propagate resourceMetadataUrl for downstream middlewares (scope-middleware)
     ctx.resourceMetadataUrl = metadataUrl;

--- a/packages/server/src/http-server_test.ts
+++ b/packages/server/src/http-server_test.ts
@@ -186,6 +186,54 @@ Deno.test("startHttp - handles tools/call", async () => {
   }
 });
 
+Deno.test("startHttp - passes execution context to tool handlers", async () => {
+  const seen: Array<{ toolName?: string; hasRequest: boolean }> = [];
+  const server = new McpApp({
+    name: "test-server",
+    version: "1.0.0",
+    logger: () => {},
+  });
+
+  server.registerTool(
+    {
+      name: "context_echo",
+      description: "Echo handler context",
+      inputSchema: { type: "object" },
+    },
+    (_args, ctx) => {
+      seen.push({
+        toolName: ctx?.toolName,
+        hasRequest: ctx?.request instanceof Request,
+      });
+      return { ok: true };
+    },
+  );
+
+  const listener = Deno.listen({ port: 0 });
+  const port = (listener.addr as Deno.NetAddr).port;
+  listener.close();
+
+  const http = await server.startHttp({ port, onListen: () => {} });
+
+  try {
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "context_echo", arguments: {} },
+      }),
+    });
+
+    await res.json();
+    assertEquals(seen, [{ toolName: "context_echo", hasRequest: true }]);
+  } finally {
+    await http.shutdown();
+  }
+});
+
 Deno.test("startHttp - handles resources/list", async () => {
   const server = new McpApp({
     name: "test-server",

--- a/packages/server/src/mcp-app.ts
+++ b/packages/server/src/mcp-app.ts
@@ -42,6 +42,7 @@ import {
   createForbiddenResponse,
   createUnauthorizedResponse,
   extractBearerToken,
+  freezeAuthInfo,
 } from "./auth/middleware.ts";
 import { createScopeMiddleware } from "./auth/scope-middleware.ts";
 import { createAuthProviderFromConfig, loadAuthConfig } from "./auth/config.ts";
@@ -600,7 +601,14 @@ export class McpApp {
       if (!tool) {
         throw new Error(`Unknown tool: ${ctx.toolName}`);
       }
-      return Promise.resolve(tool.handler(ctx.args));
+      return Promise.resolve(tool.handler(ctx.args, {
+        toolName: ctx.toolName,
+        ...(ctx.request ? { request: ctx.request } : {}),
+        ...(typeof ctx.sessionId === "string"
+          ? { sessionId: ctx.sessionId }
+          : {}),
+        ...(ctx.authInfo ? { authInfo: ctx.authInfo as AuthInfo } : {}),
+      }));
     });
   }
 
@@ -1218,7 +1226,7 @@ export class McpApp {
         };
       }
 
-      return { authInfo };
+      return { authInfo: freezeAuthInfo(authInfo) };
     };
 
     const checkHttpRateLimit = async (
@@ -2177,8 +2185,9 @@ export class McpApp {
   private buildToolListing(): Array<Record<string, unknown>> {
     return Array.from(this.tools.values())
       .filter((t) => {
-        const vis = t._meta?.ui?.visibility;
-        if (vis !== undefined && !vis.includes("model")) return false;
+        const vis = (t._meta?.ui as { visibility?: unknown } | undefined)
+          ?.visibility;
+        if (Array.isArray(vis) && !vis.includes("model")) return false;
         return true;
       })
       .map((t) => {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -439,8 +439,16 @@ export interface MCPTool {
  * };
  * ```
  */
+export interface ToolHandlerContext {
+  readonly toolName: string;
+  readonly request?: Request;
+  readonly sessionId?: string;
+  readonly authInfo?: import("./auth/types.ts").AuthInfo;
+}
+
 export type ToolHandler = (
   args: Record<string, unknown>,
+  ctx?: ToolHandlerContext,
 ) => Promise<unknown> | unknown;
 
 /**


### PR DESCRIPTION
## Summary

Ship Wave 1 of the 2026-05-18 tunnel review: 7 BLOCK fixes on
`packages/bridge/src/adapters/network/` + minor version bump to
`0.3.0`. Powers the on-prem ERP tunnel MVP coordinated across
`mcp-server` ← `mcp-erp` ← `erp-platform`.

## What landed

- **F1** Helper `allowInsecureNetworkAgentHelloForTests` removed from public exports → test-only fixture
- **F2** `NETWORK_PROTOCOL_VERSION = 1` on the wire contract; close 4002 on mismatch
- **F3** Default `concurrencyStrategy: "reject"` (one-call-at-a-time per agent). **Breaking, pre-1.0**
- **F4** `AbortSignal` end-to-end on timeout; agent slot stays busy until send settles
- **F5** `NetworkRelayError` structured class (5 codes); pending calls rejected on dispose/unregister
- **F6** `NetworkTunnelClient` reconnect loop (1s→60s, ±20% jitter, re-hello on each connect)
- **F7** `redactUrl` helper for query bearer in WS error strings

163 tests pass (`deno test --allow-net packages/bridge/`).

## Validation trail

- Multi-axis Codex review: 3 sessions (arch, safety, auth) → 7 BLOCK findings
- Fact-check pass: 7 VRAI / 0 FAUX / 0 NUANCE on this surface
- Pre-commit Codex re-review: `OVERALL: GREEN_TO_COMMIT`
- Independent local review (Claude): OK F1-F7

## Review request

@codex please review.

## Plan reference

`erp-platform/docs/superpowers/plans/2026-05-18-tunnel-review-fixes.md` (Wave 1).