### PR TITLE
fix(view): preserve literal inline bundle tokens

### DIFF
--- a/packages/view/CHANGELOG.md
+++ b/packages/view/CHANGELOG.md
@@ -7,6 +7,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-31
+
+### Fixed
+
+- Preserve literal JavaScript and CSS replacement tokens while producing an inline viewer bundle.
+  Both the `result-viewer` scaffold and the basic example now use replacement callbacks, so valid
+  source containing the dollar-ampersand, dollar-backtick, or dollar-apostrophe replacement tokens
+  cannot be interpreted as `String.prototype.replace()` replacement syntax and corrupt the generated
+  HTML.
+- Generated scaffold projects explicitly exempt their own freshly-published `@casys/mcp-view`
+  dependency from Deno's minimum dependency age, while retaining the one-day protection for every
+  other dependency.
+
 ## [0.4.0] - 2026-07-31
 
 ### Added
@@ -14,13 +27,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`@casys/mcp-view/scaffold`** — executable vanilla `result-viewer` starter:
   `deno run -A jsr:@casys/mcp-view@0.4.0/scaffold result-viewer <target>`. It emits an autonomous
   browser view with a build path, focused parser/render test, loading/empty/error states, generic
-  metrics and URI-based artifacts, host-aware accessible CSS, and no product/domain branding.
-  The generated bootstrap configures `onToolResult` before `createMcpApp()` connects, preserving the
+  metrics and URI-based artifacts, host-aware accessible CSS, and no product/domain branding. The
+  generated bootstrap configures `onToolResult` before `createMcpApp()` connects, preserving the
   initial tool result through the MCP Apps handshake.
 
-- The scaffold refuses a non-empty target by default and offers `--force` for intentional replacement
-  of scaffold files without deleting unrelated target files. Its temporary-directory tests cover
-  generation, lifecycle source shape, host-aware CSS, refusal, and explicit force.
+- The scaffold refuses a non-empty target by default and offers `--force` for intentional
+  replacement of scaffold files without deleting unrelated target files. Its temporary-directory
+  tests cover generation, lifecycle source shape, host-aware CSS, refusal, and explicit force.
 
 - Add npm packaging for `@casys/mcp-view` via `scripts/build-npm.ts` and the repository publish
   workflow. The package now follows the same JSR + npm publishing path as the other workspace

--- a/packages/view/README.md
+++ b/packages/view/README.md
@@ -48,18 +48,18 @@ structured result and render a readable evidence-style view. It is deliberately 
 not a component framework or a server generator.
 
 ```sh
-deno run -A jsr:@casys/mcp-view@0.4.0/scaffold result-viewer ./result-viewer
+deno run -A jsr:@casys/mcp-view@0.4.1/scaffold result-viewer ./result-viewer
 cd ./result-viewer
 deno task test
 deno task build
 ```
 
-The generated project is standalone and vanilla: `index.html`, `main.ts`, a generic
-model/parser, renderer, host-aware accessible styles, build script, and parser/render test. Its
-`onToolResult` callback is declared in `createMcpApp` configuration, so mcp-view registers it
-before `connect()` and preserves the initiating result during the Apps handshake. It renders
-loading, empty, error, metrics, scalar details, and URI-based artifacts without assuming an ERP,
-CAD, or other domain schema.
+The generated project is standalone and vanilla: `index.html`, `main.ts`, a generic model/parser,
+renderer, host-aware accessible styles, build script, and parser/render test. Its `onToolResult`
+callback is declared in `createMcpApp` configuration, so mcp-view registers it before `connect()`
+and preserves the initiating result during the Apps handshake. It renders loading, empty, error,
+metrics, scalar details, and URI-based artifacts without assuming an ERP, CAD, or other domain
+schema.
 
 The generator refuses a non-empty target directory. Pass `--force` only when overwriting its named
 scaffold files is intentional; unrelated files are not removed.

--- a/packages/view/deno.json
+++ b/packages/view/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-view",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",

--- a/packages/view/examples/basic/build.ts
+++ b/packages/view/examples/basic/build.ts
@@ -66,8 +66,8 @@ const css = await Deno.readTextFile(styles);
 const tpl = await Deno.readTextFile(template);
 
 const html = tpl
-  .replace("/* STYLES_PLACEHOLDER */", css)
-  .replace("/* BUNDLE_PLACEHOLDER */", js);
+  .replace("/* STYLES_PLACEHOLDER */", () => css)
+  .replace("/* BUNDLE_PLACEHOLDER */", () => js);
 
 await Deno.mkdir(outDir, { recursive: true });
 await Deno.writeTextFile(outHtml, html);

--- a/packages/view/scaffold.ts
+++ b/packages/view/scaffold.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```sh
- * deno run -A jsr:@casys/mcp-view@0.4.0/scaffold result-viewer ./my-view
+ * deno run -A jsr:@casys/mcp-view@0.4.1/scaffold result-viewer ./my-view
  * ```
  */
 
@@ -59,7 +59,7 @@ export function parseScaffoldArguments(args: readonly string[]): {
   const positional = args.filter((arg) => arg !== "--force");
   if (positional[0] !== "result-viewer" || positional.length !== 2) {
     throw new ScaffoldError(
-      "Usage: mcp-view scaffold result-viewer <target> [--force]. Example: deno run -A jsr:@casys/mcp-view@0.4.0/scaffold result-viewer ./result-viewer",
+      "Usage: mcp-view scaffold result-viewer <target> [--force]. Example: deno run -A jsr:@casys/mcp-view@0.4.1/scaffold result-viewer ./result-viewer",
     );
   }
   return { target: positional[1], options: { force } };

--- a/packages/view/scaffold_test.ts
+++ b/packages/view/scaffold_test.ts
@@ -35,20 +35,32 @@ Deno.test("result-viewer scaffold creates a standalone vanilla project in a temp
 
     const configPath = join(target, "deno.json");
     const generatedConfig = await Deno.readTextFile(configPath);
-    assertStringIncludes(generatedConfig, '"@casys/mcp-view": "jsr:@casys/mcp-view@0.4.0"');
+    assertStringIncludes(generatedConfig, '"@casys/mcp-view": "jsr:@casys/mcp-view@0.4.1"');
+    assertStringIncludes(generatedConfig, '"minimumDependencyAge"');
+    assertStringIncludes(generatedConfig, '"exclude": ["jsr:@casys/mcp-view"]');
     await Deno.writeTextFile(
       configPath,
       generatedConfig.replace(
-        "jsr:@casys/mcp-view@0.4.0",
+        "jsr:@casys/mcp-view@0.4.1",
         new URL("./mod.ts", import.meta.url).href,
       ),
+    );
+
+    await Deno.writeTextFile(
+      join(target, "src", "main.ts"),
+      '\n(globalThis as Record<string, unknown>).__mcpViewBundleReplacementProbe = "$& $` $\' $$";\n',
+      { append: true },
     );
 
     const environment = { MCP_VIEW_MODULE: new URL("./mod.ts", import.meta.url).href };
     await runGeneratedTask(target, "test", environment);
     await runGeneratedTask(target, "check", environment);
     await runGeneratedTask(target, "build", environment);
-    assert((await Deno.stat(join(target, "dist", "result-viewer", "index.html"))).isFile);
+    const generatedHtml = await Deno.readTextFile(
+      join(target, "dist", "result-viewer", "index.html"),
+    );
+    assertStringIncludes(generatedHtml, "__mcpViewBundleReplacementProbe");
+    assertInlineScriptsParse(generatedHtml);
   } finally {
     await Deno.remove(directory, { recursive: true });
   }
@@ -113,4 +125,14 @@ async function runGeneratedTask(
   throw new Error(
     `Generated result-viewer task ${task} failed:\n${new TextDecoder().decode(result.stderr)}`,
   );
+}
+
+function assertInlineScriptsParse(html: string): void {
+  const scripts = [...html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)].map((match) =>
+    match[1]
+  );
+  assert(scripts.length > 0, "expected generated viewer HTML to include an inline script");
+  for (const script of scripts) {
+    new Function(script);
+  }
 }

--- a/packages/view/src/scaffold/result-viewer-templates.ts
+++ b/packages/view/src/scaffold/result-viewer-templates.ts
@@ -6,7 +6,11 @@ export const resultViewerTemplates: Readonly<Record<string, string>> = {
     "lib": ["deno.ns", "deno.window", "dom", "dom.iterable", "dom.asynciterable", "esnext"]
   },
   "imports": {
-    "@casys/mcp-view": "jsr:@casys/mcp-view@0.4.0"
+    "@casys/mcp-view": "jsr:@casys/mcp-view@0.4.1"
+  },
+  "minimumDependencyAge": {
+    "age": "P1D",
+    "exclude": ["jsr:@casys/mcp-view"]
   },
   "tasks": {
     "build": "deno run -A build.ts",
@@ -37,7 +41,7 @@ export const resultViewerTemplates: Readonly<Record<string, string>> = {
   "build.ts": `import { dirname, fromFileUrl, join } from "jsr:@std/path@^1.1.0";
 
 const here = dirname(fromFileUrl(import.meta.url));
-const mcpViewModule = Deno.env.get("MCP_VIEW_MODULE") ?? "jsr:@casys/mcp-view@0.4.0";
+const mcpViewModule = Deno.env.get("MCP_VIEW_MODULE") ?? "jsr:@casys/mcp-view@0.4.1";
 const temporaryDirectory = await Deno.makeTempDir({ prefix: "mcp-view-result-viewer-" });
 const importMap = join(temporaryDirectory, "import-map.json");
 const bundlePath = join(temporaryDirectory, "result-viewer.js");
@@ -70,8 +74,8 @@ try {
   const css = await Deno.readTextFile(join(here, "src", "styles.css"));
   const js = await Deno.readTextFile(bundlePath);
   const html = template
-    .replace("/* STYLES_PLACEHOLDER */", css)
-    .replace("/* BUNDLE_PLACEHOLDER */", js);
+    .replace("/* STYLES_PLACEHOLDER */", () => css)
+    .replace("/* BUNDLE_PLACEHOLDER */", () => js);
   const output = join(here, "dist", "result-viewer", "index.html");
   await Deno.mkdir(dirname(output), { recursive: true });
   await Deno.writeTextFile(output, html);

--- a/packages/view/src/spec.md
+++ b/packages/view/src/spec.md
@@ -163,7 +163,7 @@ The type surface is designed so each of the above can be added without breaking 
 `@casys/mcp-view/scaffold` is an executable subpath, not part of the iframe runtime API:
 
 ```sh
-deno run -A jsr:@casys/mcp-view@0.4.0/scaffold result-viewer <target> [--force]
+deno run -A jsr:@casys/mcp-view@0.4.1/scaffold result-viewer <target> [--force]
 ```
 
 It emits a small vanilla project with an inline-HTML bundling script and no domain brand or remote


### PR DESCRIPTION
## Summary
- embed generated JavaScript and CSS through replacement callbacks so minified dollar tokens remain literal
- cover the real scaffold and the basic example with syntactic bundle validation
- prepare @casys/mcp-view 0.4.1
- keep Deno P1D protection while exempting only the freshly published mcp-view package in generated projects

## Validation
- deno task release:check (62 tests)
- generated result-viewer: test, check, build, inline-script parse
- basic example: build and inline-script parse
- deno publish --dry-run --allow-dirty