### PR TITLE
fix(server): quatre écarts à la spec 2026-07-28, dont une exposition de credentials

### DIFF
--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -4,7 +4,45 @@ All notable changes to `@casys/mcp-server` will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **Client credentials are now bound to the authorization server that minted
+  them** (spec 2026-07-28, SEP-2352). Previously `tokens()` returned stored
+  credentials to any caller. The SDK's `auth()` discovers the authorization
+  server from the **MCP server's own** protected-resource metadata and then
+  hands those tokens to `refreshAuthorization(authorizationServerUrl, …)` — so
+  an MCP server that changed, or was made to advertise, a different
+  authorization server received a refresh token minted by the previous one. A
+  client must not let a resource server choose who sees its credentials.
+
+  The binding is recorded from `saveDiscoveryState()`, which `auth()` calls
+  after discovery and before asking for tokens. Two details matter:
+
+  - It binds to the **discovered URL**, not to `metadata.issuer`. `issuer` is
+    published by the authorization server about itself, and SDK 1.29 validates
+    the metadata's shape without checking it against the URL it was fetched
+    from — so binding to the claim would let an attacker's server unlock
+    another server's credentials by claiming its name. A mismatch is logged
+    (RFC 8414 requires them to match) but nothing depends on the claim.
+  - The `refresh_token` carry-over in `saveTokens()` is now scoped to the same
+    authorization server. `auth({ authorizationCode })` reaches `saveTokens()`
+    without passing through `tokens()`, so an exchange returning no refresh
+    token would otherwise have re-labelled the previous server's secret with
+    the new issuer.
+
+  **On upgrade:** existing stored credentials carry no recorded issuer, so they
+  are discarded once and re-authorization is required. A genuine authorization
+  server migration behaves the same way — old credentials dropped, new
+  authorization performed — and both are reported through the new optional
+  `logger` on the client config.
+
 ### Added
+
+- `logger?: (message: string) => void` on the OAuth client config. Credential
+  lifecycle events — an authorization server change, a discarded legacy
+  record — are otherwise invisible, and an operator seeing an unexpected login
+  prompt has no way to find out why. URLs are redacted to origin and path
+  before being logged.
 
 - **W3C trace context propagation** (spec 2026-07-28, SEP-414). A tool-call span
   now joins the caller's trace instead of starting a detached one. `traceparent`

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 All notable changes to `@casys/mcp-server` will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **W3C trace context propagation** (spec 2026-07-28, SEP-414). A tool-call span
+  now joins the caller's trace instead of starting a detached one. `traceparent`
+  and `tracestate` are read from `params._meta` — bare, not namespaced, which
+  the revision spells out as an explicit exception to the `_meta` prefix rule so
+  the values match what a caller would put in an HTTP header — and become the
+  span's remote parent.
+
+  Both are validated against the W3C grammar rather than passed through:
+  `traceparent` follows the forward-compatibility rule (version `00` is a fixed
+  55 characters, a higher version may carry unknown trailing fields), and
+  `tracestate` members are checked against the ABNF, with invalid or duplicate
+  members dropped. The list is re-serialised onto the next hop, so accepting a
+  malformed member would turn one peer's bug into ours. `tracestate` is carried
+  through a minimal `TraceState` implementation because `@opentelemetry/api`
+  declares the interface but ships no implementation.
+
+  **`baggage` is deliberately not read.** It is an unbounded, caller-controlled
+  key/value list that routinely carries tenant, user and session identifiers,
+  and the only thing this server could do with it is copy it into spans —
+  exporting whatever a caller put there to the trace backend, with no way to
+  know whether it holds PII or a secret. Propagating it safely needs the OTel
+  baggage API and an explicit key allowlist; until a use case asks for that,
+  reading it at all is a liability.
+
+  Wired on both transports — a local stdio server is where a detached span is
+  hardest to trace back to the host that caused it. stdio now also reads
+  `io.modelcontextprotocol/logLevel`, which it previously ignored. A malformed
+  header degrades to an unparented span and never fails the call.
+
+### Fixed
+
+- **`server/discover` now answers on stdio.** The spec makes the RPC a MUST for
+  every server and names stdio as a primary use — a client probes it for
+  backward compatibility. Only the HTTP path implemented it, so a stdio peer got
+  `-32601` and concluded this was not a 2026-07-28 server. That conclusion was
+  wrong in exactly the case the probe exists for: the SDK's stdio handshake
+  negotiates `2025-11-25`, so `server/discover` is the only way a peer learns
+  the server also speaks `2026-07-28` over HTTP.
+
+  Routed through the SDK's `fallbackRequestHandler` — `setRequestHandler` takes
+  a Zod schema and the method is absent from the SDK's type surface; declaring
+  one schema is not worth a Zod peer dependency in the public API. Unknown
+  methods still answer `MethodNotFound`. Both transports now build the payload
+  from one `buildDiscoverResult()`, so `instructions` or a new capability cannot
+  land on one path only.
+
+- **Tool argument validation now runs on JSON Schema 2020-12.** The validator
+  imported ajv's default export, which is **draft-07**. Spec 2026-07-28
+  (SEP-2106) allows any 2020-12 keyword in `inputSchema` / `outputSchema`, and
+  the draft-07 build treats the keywords added in 2020-12 — `prefixItems`,
+  `unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef` — as unknown.
+  Combined with `strict: false` the failure was **silent**: the schema compiled,
+  the constraint never ran, and a violating payload validated clean. A tool
+  declaring `prefixItems: [{type:"string"}, {type:"number"}]` accepted
+  `[42, "nope"]`.
+
+  **Two breaking consequences**, both worth checking before upgrading:
+
+  1. A deployment already shipping a 2020-12 schema will see payloads that used
+     to pass now correctly fail.
+  2. A schema using the **draft-07 tuple form** — `items: [...]` with an array —
+     is now rejected by ajv at compile time, so `registerTool` throws and the
+     tool never registers. 2020-12 replaced that form with `prefixItems` and
+     requires `items` to be a single subschema. The failure is at startup, not
+     on first call, and it is deliberate: a tool whose declared boundary cannot
+     be enforced should not come up pretending it can. Migration is mechanical —
+     rename `items` to `prefixItems`.
+
+  Everything draft-07 and 2020-12 share is unaffected, including
+  `items`-as-a-single-subschema, which is the form used throughout this repo.
+  Both cases are pinned by tests.
+
+- **`fallbackRequestHandler` changes the message on unrouted methods.** The code
+  is unchanged (`-32601`), but the string a stdio peer receives goes from
+  `"Method not found"` to `"MCP error -32601: Method not found"`: an error
+  raised from a handler travels as `McpError`, whose constructor adds that
+  prefix, and there is no way to raise the code from a handler without it. Only
+  a peer matching on the message text rather than the code is affected.
+
 ## [0.24.1] — 2026-07-31
 
 ### Fixed

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@casys/mcp-server` will be documented in this file.
 
-## [Unreleased]
+## [0.25.0] — 2026-08-08
 
 ### Security
 

--- a/packages/server/deno.json
+++ b/packages/server/deno.json
@@ -22,6 +22,7 @@
     "@modelcontextprotocol/ext-apps": "npm:@modelcontextprotocol/ext-apps@^1.7.4",
     "@std/assert": "jsr:@std/assert@^1",
     "ajv": "npm:ajv@^8.17.1",
+    "ajv/dist/2020.js": "npm:ajv@^8.17.1/dist/2020.js",
     "hono": "npm:hono@^4",
     "hono/cors": "npm:hono@^4/cors",
     "jose": "npm:jose@^6.0.0",

--- a/packages/server/deno.json
+++ b/packages/server/deno.json
@@ -10,7 +10,7 @@
     "exclude": ["**/*_test.ts", "**/*.test.ts", "**/*.bench.ts"]
   },
   "tasks": {
-    "test": "deno test --allow-net --allow-read --allow-write --allow-env --no-check src/",
+    "test": "deno test --allow-net --allow-read --allow-write --allow-env --allow-run --no-check src/",
     "test:security": "deno test --allow-net --allow-read --allow-env --no-check src/http-security_test.ts",
     "test:http": "deno test --allow-net --allow-read --allow-env --no-check src/http-server_test.ts src/http-security_test.ts",
     "changelog:draft": "git -C ../.. cliff --config cliff.toml --tag-pattern 'server-v.*' --include-path 'packages/server/**' --unreleased",

--- a/packages/server/deno.json
+++ b/packages/server/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@casys/mcp-server",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts"

--- a/packages/server/src/client-auth/issuer-binding_test.ts
+++ b/packages/server/src/client-auth/issuer-binding_test.ts
@@ -1,0 +1,330 @@
+/**
+ * Credentials are bound to the authorization server that minted them (SEP-2352).
+ *
+ * The exposure this closes is concrete. `auth()` in the SDK discovers the
+ * authorization server from the MCP server's own protected-resource metadata,
+ * then hands whatever `tokens()` returns to
+ * `refreshAuthorization(authorizationServerUrl, …)`. Without a binding, an MCP
+ * server that changes — or is made to advertise — a different authorization
+ * server receives a refresh token minted by the previous one.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { OAuthClientProviderImpl } from "./provider.ts";
+import type { StoredCredentials, TokenStore } from "./types.ts";
+
+const SERVER_URL = "https://mcp.example.com";
+const AS_ONE = "https://as-one.example.com";
+const AS_TWO = "https://attacker.example.com";
+
+/** Mirrors the provider's normalisation, for asserting on what it stored. */
+function canonicalIssuerOf(value: string): string {
+  return new URL(value).href;
+}
+
+const TOKENS: OAuthTokens = {
+  access_token: "at-1",
+  refresh_token: "rt-secret",
+  token_type: "Bearer",
+};
+
+function memoryStore(seed?: StoredCredentials): TokenStore & {
+  readonly records: Map<string, StoredCredentials>;
+} {
+  const records = new Map<string, StoredCredentials>();
+  if (seed) records.set(seed.serverUrl, seed);
+
+  return {
+    records,
+    get: (url) => Promise.resolve(records.get(url) ?? null),
+    set: (url, creds) => {
+      records.set(url, creds);
+      return Promise.resolve();
+    },
+    delete: (url) => {
+      records.delete(url);
+      return Promise.resolve();
+    },
+    list: () => Promise.resolve([...records.keys()]),
+  };
+}
+
+function buildProvider(store: TokenStore, logs: string[] = []) {
+  return new OAuthClientProviderImpl(SERVER_URL, {
+    clientId: "static-client",
+    tokenStore: store,
+    openBrowser: () => Promise.resolve(),
+    logger: (message) => logs.push(message),
+  });
+}
+
+/** What `auth()` does before it asks for tokens. */
+async function discover(
+  provider: OAuthClientProviderImpl,
+  issuer: string,
+): Promise<void> {
+  await provider.saveDiscoveryState({
+    authorizationServerUrl: issuer,
+    authorizationServerMetadata: {
+      issuer,
+      response_types_supported: ["code"],
+    },
+  });
+}
+
+Deno.test("issuer binding - the refresh token is withheld from a different authorization server", async () => {
+  // The attack, end to end: credentials minted by AS_ONE, and a server now
+  // advertising AS_TWO.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: AS_ONE,
+  });
+  const logs: string[] = [];
+  const provider = buildProvider(store, logs);
+
+  await discover(provider, AS_TWO);
+
+  assertEquals(
+    await provider.tokens(),
+    undefined,
+    "the refresh token must not travel to an authorization server that did not mint it",
+  );
+  // And it is gone, so a later call with no issuer in hand cannot serve it either.
+  assertEquals(store.records.has(SERVER_URL), false);
+  assertEquals(
+    logs.some((l) => l.includes("authorization server changed")),
+    true,
+    "an operator needs to see why the login prompt reappeared",
+  );
+});
+
+Deno.test("issuer binding - the same authorization server still gets its tokens", async () => {
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: AS_ONE,
+  });
+  const provider = buildProvider(store);
+
+  await discover(provider, AS_ONE);
+
+  assertEquals((await provider.tokens())?.refresh_token, "rt-secret");
+  assertEquals(store.records.has(SERVER_URL), true);
+});
+
+Deno.test("issuer binding - legacy records with no issuer are discarded", async () => {
+  // Written before the binding existed: nothing proves who minted them.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+  });
+  const logs: string[] = [];
+  const provider = buildProvider(store, logs);
+
+  await discover(provider, AS_ONE);
+
+  assertEquals(await provider.tokens(), undefined);
+  assertEquals(store.records.has(SERVER_URL), false);
+  assertEquals(logs.some((l) => l.includes("no recorded issuer")), true);
+});
+
+Deno.test("issuer binding - a transport asking for the bearer is not blocked", async () => {
+  // `tokens()` is also called outside `auth()`, to attach a bearer to an
+  // ordinary request. No issuer is known there, and that path is not the
+  // exposure: the token goes to the MCP server it was minted for. Failing
+  // closed here would break every authenticated call instead.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+  });
+  const provider = buildProvider(store);
+
+  assertEquals((await provider.tokens())?.access_token, "at-1");
+});
+
+Deno.test("issuer binding - saveTokens records the issuer", async () => {
+  // Without this, every save writes exactly the legacy record the check above
+  // has to throw away, and the protection would look like a login loop.
+  const store = memoryStore();
+  const provider = buildProvider(store);
+
+  await discover(provider, AS_ONE);
+  await provider.saveTokens(TOKENS);
+
+  const saved = store.records.get(SERVER_URL);
+  assertExists(saved);
+  // Stored canonicalised, so a later comparison is not defeated by a trailing
+  // slash or a case difference in the host.
+  assertEquals(saved.authServerUrl, canonicalIssuerOf(AS_ONE));
+
+  // Round trip: what was just written is accepted by the same issuer.
+  assertEquals((await provider.tokens())?.refresh_token, "rt-secret");
+});
+
+Deno.test("issuer binding - the AS URL is the fallback when metadata has no issuer", async () => {
+  // A server publishing no RFC 8414 metadata still has to be bound to
+  // something; the discovered URL is what `auth()` would refresh against.
+  const store = memoryStore();
+  const provider = buildProvider(store);
+
+  await provider.saveDiscoveryState({ authorizationServerUrl: AS_ONE });
+  await provider.saveTokens(TOKENS);
+
+  assertEquals(
+    store.records.get(SERVER_URL)?.authServerUrl,
+    canonicalIssuerOf(AS_ONE),
+  );
+});
+
+Deno.test("issuer binding - invalidating discovery clears the recorded issuer", async () => {
+  // A stale issuer would make the next `tokens()` compare against an
+  // authorization server the SDK has already given up on, discarding
+  // credentials that are still valid.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: AS_ONE,
+  });
+  const provider = buildProvider(store);
+
+  await discover(provider, AS_TWO);
+  await provider.invalidateCredentials("discovery");
+
+  // No issuer in hand any more, so the stored record is served rather than
+  // judged against a server that is no longer in play.
+  const store2 = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: AS_ONE,
+  });
+  const fresh = buildProvider(store2);
+  await discover(fresh, AS_TWO);
+  await fresh.invalidateCredentials("discovery");
+
+  assertEquals((await fresh.tokens())?.access_token, "at-1");
+});
+
+Deno.test("issuer binding - a forged `issuer` claim does not unlock credentials", async () => {
+  // The bypass this design exists to close. `issuer` is published BY the
+  // authorization server, so an attacker's server reached at AS_TWO can claim
+  // to be AS_ONE. Binding to the claim would hand it the real AS_ONE tokens;
+  // binding to the URL the client actually resolved does not.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: AS_ONE,
+  });
+  const logs: string[] = [];
+  const provider = buildProvider(store, logs);
+
+  await provider.saveDiscoveryState({
+    authorizationServerUrl: AS_TWO,
+    authorizationServerMetadata: {
+      issuer: AS_ONE, // the lie
+      response_types_supported: ["code"],
+    },
+  });
+
+  assertEquals(
+    await provider.tokens(),
+    undefined,
+    "a server may not unlock another server's credentials by claiming its name",
+  );
+  assertEquals(
+    logs.some((l) => l.includes("RFC 8414 requires them to match")),
+    true,
+    "the mismatch is worth surfacing: it means broken or hostile metadata",
+  );
+});
+
+Deno.test("issuer binding - a code exchange does not inherit another server's refresh token", async () => {
+  // `auth({ authorizationCode })` calls saveTokens WITHOUT going through
+  // tokens() first, so the refresh-token carry-over is the one place a
+  // credential from a previous issuer can survive. If the exchange returns no
+  // refresh token, the old one must not be re-labelled with the new issuer.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS, // refresh_token: "rt-secret", minted by AS_ONE
+    obtainedAt: 1,
+    authServerUrl: AS_ONE,
+  });
+  const provider = buildProvider(store);
+
+  await discover(provider, AS_TWO);
+  await provider.saveTokens({ access_token: "at-new", token_type: "Bearer" });
+
+  const saved = store.records.get(SERVER_URL);
+  assertExists(saved);
+  assertEquals(
+    saved.tokens.refresh_token,
+    undefined,
+    "AS_ONE's refresh token must not be carried over to AS_TWO",
+  );
+  assertEquals(saved.authServerUrl, canonicalIssuerOf(AS_TWO));
+});
+
+Deno.test("issuer binding - the same server still inherits its own refresh token", async () => {
+  // The carry-over exists for a reason: a refresh response often omits the
+  // refresh token, and dropping it would force a full re-login every time.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: AS_ONE,
+  });
+  const provider = buildProvider(store);
+
+  await discover(provider, AS_ONE);
+  await provider.saveTokens({ access_token: "at-new", token_type: "Bearer" });
+
+  assertEquals(
+    store.records.get(SERVER_URL)?.tokens.refresh_token,
+    "rt-secret",
+  );
+});
+
+Deno.test("issuer binding - a trailing slash is not a server change", async () => {
+  // Raw string comparison would read these as different servers and wipe valid
+  // credentials on every call — a self-inflicted login loop.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: "https://as-one.example.com",
+  });
+  const provider = buildProvider(store);
+
+  await discover(provider, "https://as-one.example.com/");
+
+  assertEquals((await provider.tokens())?.access_token, "at-1");
+});
+
+Deno.test("issuer binding - logs do not leak credentials embedded in a URL", async () => {
+  // A URL may carry `userinfo`, and a query string may carry a token. Both
+  // would otherwise travel verbatim to whatever the consumer wired as a logger.
+  const store = memoryStore({
+    serverUrl: SERVER_URL,
+    tokens: TOKENS,
+    obtainedAt: 1,
+    authServerUrl: "https://user:hunter2@as-one.example.com/x?token=secret",
+  });
+  const logs: string[] = [];
+  const provider = buildProvider(store, logs);
+
+  await discover(provider, AS_TWO);
+  await provider.tokens();
+
+  const line = logs.join("\n");
+  assertEquals(line.includes("hunter2"), false, "password leaked into logs");
+  assertEquals(line.includes("secret"), false, "query token leaked into logs");
+  assertEquals(line.includes("as-one.example.com"), true, "still identifiable");
+});

--- a/packages/server/src/client-auth/provider.ts
+++ b/packages/server/src/client-auth/provider.ts
@@ -13,7 +13,10 @@ import type {
   OAuthClientMetadata,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientProvider,
+  OAuthDiscoveryState,
+} from "@modelcontextprotocol/sdk/client/auth.js";
 import type { OAuthClientConfig } from "./types.ts";
 import {
   CimdConfigError,
@@ -22,12 +25,52 @@ import {
   validateCimdClientConfig,
 } from "./client-id-metadata.ts";
 
+/**
+ * Normalise an authorization server identifier before comparing it.
+ *
+ * `https://as.example.com` and `https://as.example.com/` name the same server,
+ * and so do `HTTPS://AS.Example.com` and an explicit `:443`. Comparing raw
+ * strings would read those as a server change and wipe valid credentials on
+ * every call — a self-inflicted login loop. Falls back to the raw string if it
+ * does not parse, which then simply never matches.
+ */
+function canonicalIssuer(value: string): string {
+  try {
+    return new URL(value).href;
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * An authorization server URL, safe to put in a log line.
+ *
+ * A URL may carry `userinfo` credentials, and a query string may carry a token
+ * or an internal identifier. Origin and path are enough to tell an operator
+ * which server is involved; the rest is only a way for secrets to reach a log
+ * aggregator.
+ */
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "<unparseable url>";
+  }
+}
+
 export class OAuthClientProviderImpl implements OAuthClientProvider {
   private serverUrl: string;
   private config: OAuthClientConfig;
   private _codeVerifier = "";
   private _clientInfo: OAuthClientInformationMixed | undefined;
   private _redirectUrl: string | undefined;
+  /**
+   * Issuer the SDK resolved for the request currently being authorized
+   * (SEP-2352). Set by {@link saveDiscoveryState}, which `auth()` calls after
+   * discovery and before it asks for tokens.
+   */
+  private _currentIssuer: string | undefined;
 
   constructor(serverUrl: string, config: OAuthClientConfig) {
     const mode = resolveClientMode(config);
@@ -95,9 +138,93 @@ export class OAuthClientProviderImpl implements OAuthClientProvider {
     return Promise.resolve();
   }
 
+  /**
+   * Record the authorization server the SDK just resolved (SEP-2352).
+   *
+   * `auth()` calls this after RFC 9728 discovery and before {@link tokens},
+   * which is what makes the check there possible.
+   *
+   * The binding is the **discovered URL**, not `metadata.issuer`. That
+   * distinction is the whole protection: `issuer` is a field the authorization
+   * server publishes about itself, so an attacker's server reached at
+   * `https://attacker.example.com` can claim
+   * `issuer: "https://as-one.example.com"` and, since SDK 1.29 validates the
+   * metadata's shape without checking it against the URL it was fetched from,
+   * would be handed the credentials minted by the real AS-one. The URL the
+   * client actually resolved is the one thing in this exchange the server
+   * cannot forge.
+   *
+   * RFC 8414 does require `issuer` to match the discovery URL. A mismatch is
+   * therefore a broken or hostile authorization server, and it is logged —
+   * but nothing here depends on the claim being honest.
+   */
+  saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    const resolved = canonicalIssuer(state.authorizationServerUrl);
+    const claimed = state.authorizationServerMetadata?.issuer;
+
+    if (claimed !== undefined && canonicalIssuer(claimed) !== resolved) {
+      this.log(
+        `authorization server at ${redactUrl(state.authorizationServerUrl)} ` +
+          `claims issuer "${redactUrl(claimed)}" ` +
+          "(RFC 8414 requires them to match); " +
+          "binding credentials to the discovered URL",
+      );
+    }
+
+    this._currentIssuer = resolved;
+    return Promise.resolve();
+  }
+
+  /**
+   * Stored tokens, unless they were issued by a different authorization server.
+   *
+   * SEP-2352 makes this a MUST, and the reason is concrete rather than
+   * bureaucratic. `auth()` hands whatever this returns to
+   * `refreshAuthorization(authorizationServerUrl, …)`, where the URL comes from
+   * the MCP server's own protected-resource metadata. A server that changes —
+   * or is made to advertise — a different authorization server would therefore
+   * receive a refresh token minted by the previous one. The client must not let
+   * the resource server pick who sees its credentials.
+   *
+   * The check only runs once an issuer is known, which is the case inside
+   * `auth()`. A transport asking for the bearer to attach to an ordinary
+   * request has no issuer in hand, and that path is not the exposure: those
+   * tokens go to the MCP server they were minted for, not to an authorization
+   * server.
+   */
   async tokens(): Promise<OAuthTokens | undefined> {
     const stored = await this.config.tokenStore.get(this.serverUrl);
-    return stored?.tokens ?? undefined;
+    if (!stored) return undefined;
+    if (this._currentIssuer === undefined) return stored.tokens;
+
+    if (stored.authServerUrl === undefined) {
+      // Written before this binding existed: nothing proves which authorization
+      // server minted them. Treated as unusable rather than trusted once —
+      // the whole point is to stop handing credentials to an unverified party,
+      // and "probably fine" is the assumption this check exists to remove. The
+      // cost is one re-authorization per stored credential, at upgrade time.
+      await this.config.tokenStore.delete(this.serverUrl);
+      this.log(
+        "discarding stored credentials with no recorded issuer (SEP-2352); re-authorization required",
+      );
+      return undefined;
+    }
+
+    if (canonicalIssuer(stored.authServerUrl) !== this._currentIssuer) {
+      // A legitimate migration lands here too, and is handled the same way:
+      // drop the old credentials and let the flow re-authorize against the new
+      // server. What must not happen is the old refresh token travelling there.
+      await this.config.tokenStore.delete(this.serverUrl);
+      this.log(
+        `authorization server changed for ${redactUrl(this.serverUrl)} ` +
+          `(${redactUrl(stored.authServerUrl)} → ` +
+          `${redactUrl(this._currentIssuer)}); ` +
+          "stored credentials discarded, re-authorization required",
+      );
+      return undefined;
+    }
+
+    return stored.tokens;
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
@@ -105,8 +232,20 @@ export class OAuthClientProviderImpl implements OAuthClientProvider {
     // This get/set is not atomic; concurrent saves for one serverUrl are unsupported
     // because refresh is serialized by the caller.
     const stored = await this.config.tokenStore.get(this.serverUrl);
+
+    // …but only from the same authorization server. `auth({ authorizationCode })`
+    // reaches here without going through `tokens()`, so this is the one path
+    // where a credential from a previous issuer can survive: if the code
+    // exchange returns no refresh token, carrying the old one over would
+    // re-label another server's secret with the new issuer and hand it over on
+    // the next refresh. A legacy record has no recorded issuer, so it cannot
+    // clear this bar either.
+    const inheritable = stored?.authServerUrl !== undefined &&
+      this._currentIssuer !== undefined &&
+      canonicalIssuer(stored.authServerUrl) === this._currentIssuer;
+
     const tokensToStore = tokens.refresh_token === undefined &&
-        stored?.tokens.refresh_token !== undefined
+        inheritable && stored?.tokens.refresh_token !== undefined
       ? { ...tokens, refresh_token: stored.tokens.refresh_token }
       : tokens;
 
@@ -114,7 +253,16 @@ export class OAuthClientProviderImpl implements OAuthClientProvider {
       serverUrl: this.serverUrl,
       tokens: tokensToStore,
       obtainedAt: Date.now(),
+      // Binds the credentials to their minter. Without it every save produces
+      // exactly the legacy record `tokens()` has to throw away.
+      ...(this._currentIssuer !== undefined
+        ? { authServerUrl: this._currentIssuer }
+        : {}),
     });
+  }
+
+  private log(message: string): void {
+    this.config.logger?.(`[client-auth] ${message}`);
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
@@ -141,6 +289,12 @@ export class OAuthClientProviderImpl implements OAuthClientProvider {
     }
     if (scope === "all" || scope === "client") {
       this._clientInfo = undefined;
+    }
+    if (scope === "all" || scope === "discovery") {
+      // Keeping a stale issuer would make the next `tokens()` compare against
+      // an authorization server the SDK has already given up on, and discard
+      // credentials that are in fact still valid.
+      this._currentIssuer = undefined;
     }
   }
 }

--- a/packages/server/src/client-auth/provider_test.ts
+++ b/packages/server/src/client-auth/provider_test.ts
@@ -62,6 +62,14 @@ Deno.test("OAuthClientProviderImpl - saveTokens preserves existing refresh_token
     openBrowser: async () => {},
   });
 
+  // Discovery first, exactly as `auth()` does before it ever saves tokens.
+  // Since SEP-2352 the carry-over is scoped to one authorization server, so
+  // this keeps the test on the real code path rather than a shape `auth()`
+  // never produces. The boundary itself lives in issuer-binding_test.ts.
+  await provider.saveDiscoveryState({
+    authorizationServerUrl: "https://as.example.com",
+  });
+
   await provider.saveTokens({
     access_token: "access-123",
     token_type: "bearer",

--- a/packages/server/src/client-auth/types.ts
+++ b/packages/server/src/client-auth/types.ts
@@ -18,7 +18,12 @@ export interface StoredCredentials {
   tokens: OAuthTokens;
   /** When the tokens were obtained (Unix epoch ms) */
   obtainedAt: number;
-  /** Authorization server URL (needed for refresh) */
+  /**
+   * Issuer that minted these credentials (SEP-2352).
+   *
+   * Absent on records written before the binding existed; `tokens()` treats
+   * that as unusable, since nothing proves who minted them.
+   */
   authServerUrl?: string;
 }
 
@@ -48,6 +53,14 @@ export interface OAuthClientConfigBase {
   callbackPort?: number;
   /** Timeout for user to complete OAuth flow (ms, default: 120_000) */
   authTimeout?: number;
+  /**
+   * Optional sink for credential-lifecycle events.
+   *
+   * Notably an authorization-server change (SEP-2352): the client silently
+   * drops its stored credentials and re-authorizes, and an operator debugging
+   * an unexpected login prompt has no other way to see why.
+   */
+  logger?: (message: string) => void;
 }
 
 /** Static OAuth client registration (default, backwards-compatible mode). */

--- a/packages/server/src/mcp-app.ts
+++ b/packages/server/src/mcp-app.ts
@@ -18,8 +18,10 @@ import {
   type ClientCapabilities,
   ErrorCode,
   type Implementation,
+  type JSONRPCRequest,
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  McpError,
   type ReadResourceRequest,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -102,7 +104,12 @@ import {
   type SubscriptionSink,
 } from "./subscriptions/subscription-registry.ts";
 import { ServerMetrics } from "./observability/metrics.ts";
-import { endToolCallSpan, startToolCallSpan } from "./observability/otel.ts";
+import type { SpanContext } from "@opentelemetry/api";
+import {
+  endToolCallSpan,
+  parseTraceParent,
+  startToolCallSpan,
+} from "./observability/otel.ts";
 import {
   BodyTooLargeError,
   DEFAULT_MAX_BODY_BYTES,
@@ -160,6 +167,16 @@ const STATELESS_SERVER_INFO_KEY = "io.modelcontextprotocol/serverInfo";
  */
 const STATELESS_LOG_LEVEL_KEY = "io.modelcontextprotocol/logLevel";
 
+/**
+ * W3C trace context keys in `params._meta` (spec 2026-07-28, SEP-414).
+ *
+ * Unlike every other per-request field these are NOT namespaced — the revision
+ * documents the bare W3C names, so that a `_meta` envelope carries the same
+ * key a caller would put in an HTTP header.
+ */
+const TRACEPARENT_KEY = "traceparent";
+const TRACESTATE_KEY = "tracestate";
+
 /** Protocol version whose wire format this server implements natively */
 const SPEC_2026_07_28 = "2026-07-28";
 
@@ -212,6 +229,34 @@ interface StatelessClientMeta {
   readonly clientInfo?: Implementation;
   readonly clientCapabilities?: ClientCapabilities;
   readonly logLevel?: McpLogLevel;
+  /** Caller's W3C trace context, so the tool span joins their trace. */
+  readonly traceContext?: SpanContext;
+}
+
+/**
+ * Read the W3C trace context out of `params._meta` (spec 2026-07-28, SEP-414).
+ *
+ * A malformed header leaves the span unparented rather than failing the call:
+ * losing the trace join is an observability gap, refusing the tool call would
+ * be an outage.
+ *
+ * `baggage` is deliberately NOT read. It is an unbounded, caller-controlled
+ * key/value list that routinely carries tenant, user and session identifiers,
+ * and the only thing this server could do with it is copy it into spans —
+ * exporting whatever a caller put there to the trace backend, with no way to
+ * know whether it holds a PII or a secret. Propagating it properly means the
+ * OTel baggage API and an explicit allowlist of keys; until there is a use case
+ * asking for that, reading it at all is a liability. The key stays reserved by
+ * the spec, and this server ignores it.
+ */
+function readTraceContext(
+  meta: Record<string, unknown>,
+): { traceContext?: SpanContext } {
+  const traceContext = parseTraceParent(
+    meta[TRACEPARENT_KEY],
+    meta[TRACESTATE_KEY],
+  );
+  return traceContext ? { traceContext } : {};
 }
 
 /** Valid `io.modelcontextprotocol/logLevel` values (RFC 5424 severities). */
@@ -661,9 +706,31 @@ export class McpApp {
         const toolName = request.params.name;
         const args = request.params.arguments || {};
 
+        // Per-request `_meta` is transport-independent. Trace context matters
+        // here because a local server is exactly where a detached span is
+        // hardest to correlate back to the host that caused it; `logLevel` is
+        // read for the same reason it is on HTTP — the spec makes it
+        // per-request, and a handler must stay silent without it.
+        const meta = request.params._meta;
+        const clientMeta: StatelessClientMeta | undefined = isRecord(meta)
+          ? {
+            ...readTraceContext(meta),
+            ...(readLogLevel(meta) !== undefined
+              ? { logLevel: readLogLevel(meta) }
+              : {}),
+          }
+          : undefined;
+
         let result: unknown;
         try {
-          result = await this.executeToolCall(toolName, args);
+          result = await this.executeToolCall(
+            toolName,
+            args,
+            undefined,
+            undefined,
+            undefined,
+            clientMeta,
+          );
         } catch (error) {
           return this.handleToolError(error, toolName);
         }
@@ -672,6 +739,66 @@ export class McpApp {
         // let them propagate
         return this.buildToolCallResult(toolName, result);
       },
+    );
+
+    // `server/discover` over stdio (spec 2026-07-28, SEP-2575).
+    //
+    // The spec makes this RPC a MUST for every server and names stdio as a
+    // primary use: a client probes it for backward compatibility. That matters
+    // here precisely because the SDK's stdio handshake still negotiates
+    // 2025-11-25 — `server/discover` is then the only way for a peer to learn
+    // this server also speaks 2026-07-28 over HTTP.
+    //
+    // Routed through `fallbackRequestHandler` rather than `setRequestHandler`
+    // because the latter takes a Zod schema, and the method is absent from the
+    // SDK's type surface. Adding a Zod dependency to declare one schema would
+    // put a peer dependency in the public API for a single string comparison.
+    // Every other unknown method keeps its previous answer: MethodNotFound.
+    server.fallbackRequestHandler = (request: JSONRPCRequest) => {
+      if (request.method !== "server/discover") {
+        // Same text the SDK used for an unrouted method. It still reaches the
+        // wire as "MCP error -32601: Method not found" — `McpError` prefixes
+        // its own message and a handler cannot raise the code without it. The
+        // code is unchanged, which is what a peer switches on; the string
+        // difference is pinned by a test and noted in the changelog. Appending
+        // the method name on top of that would have been a second, gratuitous
+        // change to the same field.
+        throw new McpError(ErrorCode.MethodNotFound, "Method not found");
+      }
+      return Promise.resolve(this.buildDiscoverResult());
+    };
+  }
+
+  /**
+   * The `server/discover` result (spec 2026-07-28, SEP-2575).
+   *
+   * Single source of truth for both transports. They used to be one inline
+   * object on the HTTP path; a stdio copy would have been the second place to
+   * forget `instructions` or a new capability.
+   *
+   * Always stamped as 2026-07-28 regardless of what the transport negotiated.
+   * That is deliberate but not free: nothing gates the method, so a peer that
+   * negotiated `2025-11-25` over stdio can call it and receive an envelope it
+   * never agreed to. The alternative is worse — stamping the negotiated version
+   * would make the probe answer "2025" to the client asking whether this server
+   * speaks 2026, which is the one question it exists to answer. Treat
+   * `server/discover` as a cross-version exception: its result describes what
+   * the server supports, not what the current transport negotiated.
+   */
+  private buildDiscoverResult(): Record<string, unknown> {
+    return this.stampResult(
+      this.withCacheHints({
+        supportedVersions: [...STATELESS_SUPPORTED_VERSIONS],
+        capabilities: this.buildServerCapabilities(),
+        serverInfo: {
+          name: this.options.name,
+          version: this.options.version,
+        },
+        ...(this.options.instructions
+          ? { instructions: this.options.instructions }
+          : {}),
+      }, SPEC_2026_07_28),
+      SPEC_2026_07_28,
     );
   }
 
@@ -1008,12 +1135,16 @@ export class McpApp {
     };
 
     // OTel span + metrics
-    const span = startToolCallSpan(toolName, {
-      "mcp.tool.name": toolName,
-      "mcp.server.name": this.options.name,
-      "mcp.transport": request ? "http" : "stdio",
-      "mcp.session.id": sessionId,
-    });
+    const span = startToolCallSpan(
+      toolName,
+      {
+        "mcp.tool.name": toolName,
+        "mcp.server.name": this.options.name,
+        "mcp.transport": request ? "http" : "stdio",
+        "mcp.session.id": sessionId,
+      },
+      clientMeta?.traceContext,
+    );
 
     // Update gauges before execution
     const queueMetrics = this.requestQueue.getMetrics();
@@ -1927,20 +2058,7 @@ export class McpApp {
           return c.json({
             jsonrpc: "2.0",
             id,
-            result: this.stampResult(
-              this.withCacheHints({
-                supportedVersions: [...STATELESS_SUPPORTED_VERSIONS],
-                capabilities: this.buildServerCapabilities(),
-                serverInfo: {
-                  name: this.options.name,
-                  version: this.options.version,
-                },
-                ...(this.options.instructions
-                  ? { instructions: this.options.instructions }
-                  : {}),
-              }, statelessVersion),
-              statelessVersion,
-            ),
+            result: this.buildDiscoverResult(),
           });
         }
 
@@ -2005,6 +2123,7 @@ export class McpApp {
                   STATELESS_CLIENT_CAPABILITIES_KEY
                 ] as ClientCapabilities | undefined,
                 logLevel: readLogLevel(params["_meta"]),
+                ...readTraceContext(params["_meta"]),
               }
               : undefined;
 

--- a/packages/server/src/observability/mod.ts
+++ b/packages/server/src/observability/mod.ts
@@ -12,6 +12,7 @@ export {
   endToolCallSpan,
   getServerTracer,
   isOtelEnabled,
+  parseTraceParent,
   recordAuthEvent,
   startToolCallSpan,
   type ToolCallSpanAttributes,

--- a/packages/server/src/observability/otel.ts
+++ b/packages/server/src/observability/otel.ts
@@ -11,14 +11,224 @@
  */
 
 import {
+  type Context,
+  context as otelContext,
   type Span,
+  type SpanContext,
   SpanStatusCode,
   trace,
+  TraceFlags,
   type Tracer,
+  type TraceState,
 } from "@opentelemetry/api";
 import { env } from "../runtime/runtime.ts";
 
 let serverTracer: Tracer | null = null;
+
+/**
+ * W3C `traceparent`: `<2 hex version>-<32 hex trace-id>-<16 hex parent-id>-<2 hex flags>`.
+ *
+ * Matches the 55-character prefix only — the trailing-content rule depends on
+ * the version and is applied separately, see {@link parseTraceParent}.
+ *
+ * Case-sensitive on purpose. The spec mandates lowercase hex, and accepting
+ * uppercase produces a trace id that will not match the same trace elsewhere in
+ * the pipeline: a silently broken join is worse than a dropped header.
+ */
+const TRACEPARENT = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})/;
+
+/** `00-` + 32 + `-` + 16 + `-` + 2 = 55. */
+const TRACEPARENT_PREFIX_LENGTH = 55;
+
+/** All-zero ids are explicitly invalid in the W3C spec. */
+const INVALID_TRACE_ID = "0".repeat(32);
+const INVALID_SPAN_ID = "0".repeat(16);
+
+/** W3C caps `tracestate` at 32 list members; the rest are dropped. */
+const TRACESTATE_MAX_MEMBERS = 32;
+
+/**
+ * W3C `tracestate` key, both forms of the ABNF:
+ * - simple: `lcalpha 0*255(lcalpha / DIGIT / "_" / "-" / "*" / "/")`
+ * - multi-tenant: `tenant-id "@" system-id`
+ */
+const TRACESTATE_KEY =
+  /^(?:[a-z][a-z0-9_\-*/]{0,255}|[a-z0-9][a-z0-9_\-*/]{0,240}@[a-z][a-z0-9_\-*/]{0,13})$/;
+
+/**
+ * W3C `tracestate` value — the ABNF is `0*255(chr) nblk-chr`:
+ *
+ * - `chr` is printable ASCII except comma and equals. `=` inside a value is
+ *   forbidden, so a member carrying one is malformed, not a value to preserve.
+ * - the final character is `nblk-chr`, which additionally excludes SP. That
+ *   makes the value **non-empty** and forbids a trailing space, so `vendor=`
+ *   is not a valid member.
+ */
+const TRACESTATE_VALUE =
+  /^[\x20-\x2B\x2D-\x3C\x3E-\x7E]{0,255}[\x21-\x2B\x2D-\x3C\x3E-\x7E]$/;
+
+/**
+ * The grammar's optional whitespace around a list member is SP and HTAB only.
+ * `String.trim()` also eats CR, LF, FF, VT and Unicode spaces — none of which
+ * are legal separators here, so trimming with it would silently accept a
+ * malformed list.
+ */
+function trimOws(member: string): string {
+  return member.replace(/^[ \t]+/, "").replace(/[ \t]+$/, "");
+}
+
+/**
+ * `tracestate` carried to the next hop.
+ *
+ * `@opentelemetry/api` declares the interface but ships no implementation —
+ * that lives in `@opentelemetry/core`. Pulling in the SDK package for one
+ * key/value list would put a second OTel dependency in the public API, so this
+ * is the minimum that satisfies the interface.
+ *
+ * Members are validated against the W3C ABNF rather than passed through: the
+ * spec permits discarding invalid entries, and this list is re-serialised onto
+ * the next hop — accepting a malformed member here means emitting a malformed
+ * `tracestate` downstream, turning one peer's bug into ours.
+ */
+class ListTraceState implements TraceState {
+  readonly #entries: ReadonlyArray<readonly [string, string]>;
+
+  constructor(entries: ReadonlyArray<readonly [string, string]>) {
+    this.#entries = entries;
+  }
+
+  static #isValid(key: string, value: string): boolean {
+    return TRACESTATE_KEY.test(key) && TRACESTATE_VALUE.test(value);
+  }
+
+  static parse(raw: string): ListTraceState | undefined {
+    const seen = new Set<string>();
+    const entries: Array<readonly [string, string]> = [];
+
+    for (const member of raw.split(",")) {
+      // Optional whitespace around a list member is part of the grammar; the
+      // key and value themselves are matched exactly.
+      const trimmed = trimOws(member);
+      if (trimmed.length === 0) continue;
+
+      const at = trimmed.indexOf("=");
+      if (at <= 0) continue;
+
+      const key = trimmed.slice(0, at);
+      const value = trimmed.slice(at + 1);
+      // Duplicate keys are invalid; the first occurrence is the live one.
+      if (seen.has(key)) continue;
+      if (!ListTraceState.#isValid(key, value)) continue;
+
+      seen.add(key);
+      entries.push([key, value]);
+      if (entries.length === TRACESTATE_MAX_MEMBERS) break;
+    }
+
+    return entries.length > 0 ? new ListTraceState(entries) : undefined;
+  }
+
+  get(key: string): string | undefined {
+    return this.#entries.find(([k]) => k === key)?.[1];
+  }
+
+  set(key: string, value: string): TraceState {
+    // Returns the state unchanged rather than throwing. The OpenTelemetry
+    // specification is explicit that "API methods MUST NOT throw unhandled
+    // exceptions when used incorrectly by end users" — telemetry is not worth
+    // taking an application down for. Rejecting the mutation still keeps the
+    // invalid member off the wire, which is the property that matters.
+    if (!ListTraceState.#isValid(key, value)) return this;
+    // W3C: a mutated key moves to the front of the list.
+    return new ListTraceState([
+      [key, value] as const,
+      ...this.#entries.filter(([k]) => k !== key),
+    ].slice(0, TRACESTATE_MAX_MEMBERS));
+  }
+
+  unset(key: string): TraceState {
+    return new ListTraceState(this.#entries.filter(([k]) => k !== key));
+  }
+
+  serialize(): string {
+    return this.#entries.map(([k, v]) => `${k}=${v}`).join(",");
+  }
+}
+
+/**
+ * Parse a W3C trace context into an OTel `SpanContext` (spec 2026-07-28).
+ *
+ * The revision documents `traceparent` / `tracestate` / `baggage` as `_meta`
+ * keys so a tool call joins the caller's trace instead of starting a detached
+ * one. Returns `undefined` for anything malformed — a bad header leaves the span
+ * unparented, it never fails the call.
+ *
+ * Version handling follows the W3C forward-compatibility rule, which is not
+ * "reject anything unfamiliar":
+ *
+ * - `ff` is forbidden outright.
+ * - `00` is a fixed 55-character format; anything longer is malformed.
+ * - a higher version MAY carry fields this implementation does not know. The
+ *   receiver parses the first 55 characters and ignores the rest, provided the
+ *   next character is a `-`. Rejecting those would make this server drop trace
+ *   context the day a new version ships — the exact breakage the rule exists to
+ *   prevent.
+ */
+export function parseTraceParent(
+  traceparent: unknown,
+  tracestate?: unknown,
+): SpanContext | undefined {
+  if (typeof traceparent !== "string") return undefined;
+  if (traceparent.length < TRACEPARENT_PREFIX_LENGTH) return undefined;
+
+  const match = TRACEPARENT.exec(traceparent);
+  if (!match) return undefined;
+
+  const [, version, traceId, spanId, flags] = match;
+  if (version === "ff") return undefined;
+
+  if (version === "00") {
+    if (traceparent.length !== TRACEPARENT_PREFIX_LENGTH) return undefined;
+  } else if (
+    traceparent.length > TRACEPARENT_PREFIX_LENGTH &&
+    traceparent[TRACEPARENT_PREFIX_LENGTH] !== "-"
+  ) {
+    // Longer, but not a well-formed continuation: the extra characters are not
+    // a new field, so the whole header is suspect.
+    return undefined;
+  }
+
+  if (traceId === INVALID_TRACE_ID || spanId === INVALID_SPAN_ID) {
+    return undefined;
+  }
+
+  const traceState = typeof tracestate === "string"
+    ? ListTraceState.parse(tracestate)
+    : undefined;
+
+  return {
+    traceId,
+    spanId,
+    // Only the sampled bit is defined; the rest of the byte is reserved.
+    traceFlags: (parseInt(flags, 16) & TraceFlags.SAMPLED) as TraceFlags,
+    isRemote: true,
+    ...(traceState ? { traceState } : {}),
+  };
+}
+
+/**
+ * The OTel context a remote `SpanContext` should parent, or the active one.
+ *
+ * Note the fallback is the *active* context, not `ROOT_CONTEXT`: with no
+ * caller-supplied trace context the span attaches to whatever span is active in
+ * this process, and only becomes a root when there is none. That is the right
+ * default — it preserves in-process nesting — but it means "no traceparent" and
+ * "root span" are not synonyms.
+ */
+function parentContext(remote?: SpanContext): Context {
+  const active = otelContext.active();
+  return remote ? trace.setSpanContext(active, remote) : active;
+}
 
 /**
  * Get or create the MCP server tracer
@@ -46,13 +256,24 @@ export interface ToolCallSpanAttributes {
 /**
  * Start a span for a tool call.
  * Caller MUST call span.end() when done.
+ *
+ * `remoteParent` is the caller's trace context, read from the request's `_meta`
+ * (spec 2026-07-28). With it the span joins the caller's trace; without it the
+ * span falls back to the active context, which is what every call produced
+ * before the `_meta` keys were wired in — a server-side trace nobody could
+ * correlate to the client that caused it.
  */
 export function startToolCallSpan(
   toolName: string,
   attributes: ToolCallSpanAttributes,
+  remoteParent?: SpanContext,
 ): Span {
   const tracer = getServerTracer();
-  return tracer.startSpan(`mcp.tool.call ${toolName}`, { attributes });
+  return tracer.startSpan(
+    `mcp.tool.call ${toolName}`,
+    { attributes },
+    parentContext(remoteParent),
+  );
 }
 
 /**

--- a/packages/server/src/observability/trace-context_test.ts
+++ b/packages/server/src/observability/trace-context_test.ts
@@ -1,0 +1,248 @@
+/**
+ * W3C trace context parsing (spec 2026-07-28, SEP-414).
+ *
+ * `traceparent` / `tracestate` / `baggage` are the one exception to the `_meta`
+ * prefix rule — the spec reserves the bare W3C names so a `_meta` envelope
+ * carries what an HTTP header would.
+ *
+ * The rejection cases matter more than the happy path: a malformed header that
+ * parses anyway produces a span attached to a trace id nobody else has, which
+ * reads as a real correlation and is not one.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { TraceFlags } from "@opentelemetry/api";
+import { parseTraceParent } from "./otel.ts";
+
+const TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+const SPAN_ID = "00f067aa0ba902b7";
+const SAMPLED = `00-${TRACE_ID}-${SPAN_ID}-01`;
+
+Deno.test("traceparent - parses the W3C example", () => {
+  const ctx = parseTraceParent(SAMPLED);
+
+  assertExists(ctx);
+  assertEquals(ctx.traceId, TRACE_ID);
+  assertEquals(ctx.spanId, SPAN_ID);
+  assertEquals(ctx.traceFlags, TraceFlags.SAMPLED);
+  assertEquals(ctx.isRemote, true);
+});
+
+Deno.test("traceparent - an unsampled flag is preserved, not dropped", () => {
+  // `00` means "not sampled", which is a decision to honour — not a reason to
+  // discard the parent and start a detached trace.
+  const ctx = parseTraceParent(`00-${TRACE_ID}-${SPAN_ID}-00`);
+
+  assertExists(ctx);
+  assertEquals(ctx.traceFlags, TraceFlags.NONE);
+  assertEquals(ctx.traceId, TRACE_ID);
+});
+
+Deno.test("traceparent - reserved flag bits are masked off", () => {
+  // Only the low bit is defined. A future spec may set others; a receiver must
+  // not read them as sampling.
+  const ctx = parseTraceParent(`00-${TRACE_ID}-${SPAN_ID}-ff`);
+
+  assertExists(ctx);
+  assertEquals(ctx.traceFlags, TraceFlags.SAMPLED);
+});
+
+Deno.test("traceparent - a future version parses as version 00", () => {
+  const ctx = parseTraceParent(`cc-${TRACE_ID}-${SPAN_ID}-01`);
+
+  assertExists(ctx);
+  assertEquals(ctx.traceId, TRACE_ID);
+});
+
+Deno.test("traceparent - a future version may carry unknown trailing fields", () => {
+  // The W3C forward-compatibility rule: a receiver parses the first 55
+  // characters and ignores the rest when the next character is `-`. Rejecting
+  // these would make this server drop trace context the day a version 01 ships
+  // — the exact breakage the rule exists to prevent.
+  const ctx = parseTraceParent(`cc-${TRACE_ID}-${SPAN_ID}-01-futurefield`);
+
+  assertExists(ctx);
+  assertEquals(ctx.traceId, TRACE_ID);
+  assertEquals(ctx.spanId, SPAN_ID);
+  assertEquals(ctx.traceFlags, TraceFlags.SAMPLED);
+});
+
+Deno.test("traceparent - trailing content must start a new field", () => {
+  // Longer than 55 but the 56th character is not a separator: the extra
+  // characters are not a field, so the header is malformed rather than future.
+  assertEquals(
+    parseTraceParent(`cc-${TRACE_ID}-${SPAN_ID}-01x`),
+    undefined,
+  );
+});
+
+Deno.test("traceparent - version 00 is a fixed 55-character format", () => {
+  // The forward-compatibility allowance is for *higher* versions only. Version
+  // 00 has no additional fields, so trailing content is corruption.
+  assertEquals(parseTraceParent(`${SAMPLED}-extra`), undefined);
+  assertEquals(parseTraceParent(`${SAMPLED}x`), undefined);
+  assertEquals(parseTraceParent(SAMPLED)?.traceId, TRACE_ID);
+});
+
+Deno.test("traceparent - malformed values are rejected", () => {
+  const rejected = [
+    undefined,
+    null,
+    42,
+    "",
+    "not-a-traceparent",
+    // Version ff is forbidden outright by W3C.
+    `ff-${TRACE_ID}-${SPAN_ID}-01`,
+    // All-zero ids are explicitly invalid.
+    `00-${"0".repeat(32)}-${SPAN_ID}-01`,
+    `00-${TRACE_ID}-${"0".repeat(16)}-01`,
+    // Uppercase hex: accepting it yields an id that will not match the same
+    // trace elsewhere in the pipeline.
+    `00-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01`,
+    // Wrong lengths.
+    `00-${TRACE_ID.slice(0, 31)}-${SPAN_ID}-01`,
+    `00-${TRACE_ID}-${SPAN_ID}0-01`,
+    // Leading whitespace shifts every field.
+    ` ${SAMPLED}`,
+  ];
+
+  for (const value of rejected) {
+    assertEquals(
+      parseTraceParent(value),
+      undefined,
+      `expected rejection for ${JSON.stringify(value)}`,
+    );
+  }
+});
+
+Deno.test("tracestate - vendor entries survive a round trip", () => {
+  const ctx = parseTraceParent(SAMPLED, "vendor1=abc,vendor2=def");
+
+  assertExists(ctx?.traceState);
+  assertEquals(ctx.traceState.get("vendor1"), "abc");
+  assertEquals(ctx.traceState.get("vendor2"), "def");
+  assertEquals(ctx.traceState.serialize(), "vendor1=abc,vendor2=def");
+});
+
+Deno.test("tracestate - a value containing '=' is a malformed member", () => {
+  // The W3C ABNF excludes `=` (0x3D) and `,` (0x2C) from a value. Preserving
+  // such a member would put it back on the wire on the next hop, turning one
+  // peer's malformed header into ours.
+  const ctx = parseTraceParent(SAMPLED, "vendor=a=b=c");
+
+  assertEquals(ctx?.traceState, undefined);
+});
+
+Deno.test("tracestate - one malformed member does not discard the valid ones", () => {
+  const ctx = parseTraceParent(SAMPLED, "good=1,BAD-UPPER=2,also_good=3");
+
+  assertEquals(ctx?.traceState?.get("good"), "1");
+  assertEquals(ctx?.traceState?.get("also_good"), "3");
+  assertEquals(ctx?.traceState?.get("BAD-UPPER"), undefined);
+  assertEquals(ctx?.traceState?.serialize(), "good=1,also_good=3");
+});
+
+Deno.test("tracestate - keys are validated against the ABNF", () => {
+  // Simple keys are lowercase-led; the multi-tenant form allows one `@`.
+  assertEquals(
+    parseTraceParent(SAMPLED, "congo@vendor=t61")?.traceState?.get(
+      "congo@vendor",
+    ),
+    "t61",
+  );
+  assertEquals(parseTraceParent(SAMPLED, "1nvalid=x")?.traceState, undefined);
+  assertEquals(parseTraceParent(SAMPLED, "has space=x")?.traceState, undefined);
+  assertEquals(parseTraceParent(SAMPLED, "a@b@c=x")?.traceState, undefined);
+});
+
+Deno.test("tracestate - a duplicate key keeps the first occurrence", () => {
+  const ctx = parseTraceParent(SAMPLED, "dup=first,dup=second");
+
+  assertEquals(ctx?.traceState?.get("dup"), "first");
+  assertEquals(ctx?.traceState?.serialize(), "dup=first");
+});
+
+Deno.test("tracestate - surrounding whitespace is tolerated, per the OWS rule", () => {
+  // The grammar puts optional whitespace around list members, so stripping SP
+  // and HTAB there is correct. The value's own no-trailing-space rule is
+  // enforced separately, by the ABNF pattern.
+  const ctx = parseTraceParent(SAMPLED, " a=1 , b=2 ");
+
+  assertEquals(ctx?.traceState?.get("a"), "1");
+  assertEquals(ctx?.traceState?.get("b"), "2");
+  assertEquals(ctx?.traceState?.serialize(), "a=1,b=2");
+});
+
+Deno.test("tracestate - an internal space in a value is preserved", () => {
+  // 0x20 is inside the allowed range; only the trailing position is excluded.
+  assertEquals(parseTraceParent(SAMPLED, "v=a b")?.traceState?.get("v"), "a b");
+});
+
+Deno.test("tracestate - set drops an invalid member without throwing", () => {
+  // The OTel spec forbids an API method from throwing on incorrect use:
+  // telemetry must not be able to take an application down. Returning the state
+  // unchanged still keeps the invalid member off the wire.
+  const state = parseTraceParent(SAMPLED, "a=1")?.traceState;
+  assertExists(state);
+
+  assertEquals(state.set("bad key", "x").serialize(), "a=1");
+  assertEquals(state.set("ok", "has=equals").serialize(), "a=1");
+  assertEquals(state.set("ok", "").serialize(), "a=1");
+
+  // A valid mutation still applies.
+  assertEquals(state.set("b", "2").serialize(), "b=2,a=1");
+});
+
+Deno.test("tracestate - an empty value is not a valid member", () => {
+  // The ABNF ends the value with `nblk-chr`, so it cannot be empty.
+  assertEquals(parseTraceParent(SAMPLED, "vendor=")?.traceState, undefined);
+  assertEquals(
+    parseTraceParent(SAMPLED, "empty=,full=1")?.traceState?.serialize(),
+    "full=1",
+  );
+});
+
+Deno.test("tracestate - only SP and HTAB separate list members", () => {
+  // `String.trim()` would also eat CR/LF/FF/VT, none of which are legal here.
+  // Accepting them means accepting a malformed list.
+  assertEquals(parseTraceParent(SAMPLED, "a=1,\nb=2")?.traceState?.get("b"), undefined);
+  assertEquals(parseTraceParent(SAMPLED, "\ta=1 ")?.traceState?.get("a"), "1");
+});
+
+Deno.test("tracestate - list is capped at 32 members", () => {
+  const raw = Array.from({ length: 40 }, (_, i) => `v${i}=x`).join(",");
+  const ctx = parseTraceParent(SAMPLED, raw);
+
+  assertEquals(ctx?.traceState?.serialize().split(",").length, 32);
+  assertEquals(ctx?.traceState?.get("v31"), "x");
+  assertEquals(ctx?.traceState?.get("v32"), undefined);
+});
+
+Deno.test("tracestate - set moves a mutated key to the front", () => {
+  const ctx = parseTraceParent(SAMPLED, "a=1,b=2");
+  const mutated = ctx?.traceState?.set("b", "9");
+
+  assertEquals(mutated?.serialize(), "b=9,a=1");
+});
+
+Deno.test("tracestate - unset removes a key", () => {
+  const ctx = parseTraceParent(SAMPLED, "a=1,b=2");
+
+  assertEquals(ctx?.traceState?.unset("a").serialize(), "b=2");
+});
+
+Deno.test("tracestate - absent or unusable values leave no traceState", () => {
+  assertEquals(parseTraceParent(SAMPLED)?.traceState, undefined);
+  assertEquals(parseTraceParent(SAMPLED, "")?.traceState, undefined);
+  assertEquals(parseTraceParent(SAMPLED, "garbage")?.traceState, undefined);
+  assertEquals(parseTraceParent(SAMPLED, 42)?.traceState, undefined);
+});
+
+Deno.test("tracestate - a bad tracestate never invalidates the traceparent", () => {
+  // The two headers are independent: dropping the parent because a vendor sent
+  // a malformed tracestate would lose the correlation over a detail.
+  const ctx = parseTraceParent(SAMPLED, "=novalue");
+
+  assertExists(ctx);
+  assertEquals(ctx.traceId, TRACE_ID);
+});

--- a/packages/server/src/observability/trace-wiring_test.ts
+++ b/packages/server/src/observability/trace-wiring_test.ts
@@ -1,0 +1,202 @@
+/**
+ * End-to-end wiring of `_meta` trace context through a tool call.
+ *
+ * `trace-context_test.ts` proves the parser. This proves the plumbing, which is
+ * the part that fails silently: every unit test there would still pass if
+ * `readTraceContext` were never called, or if its result landed in the wrong
+ * positional argument of `executeToolCall` and quietly became `mrtr`.
+ *
+ * Spans are captured through a fake global `TracerProvider`, registered once at
+ * module load — see the note on the buffer below for why it cannot be per-test.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  type Context,
+  type Span,
+  type SpanContext,
+  trace,
+  type Tracer,
+  type TracerProvider,
+} from "@opentelemetry/api";
+import { McpApp } from "../mcp-app.ts";
+
+const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID = "00f067aa0ba902b7";
+const TRACEPARENT = `00-${TRACE_ID}-${SPAN_ID}-01`;
+
+interface Captured {
+  readonly name: string;
+  readonly parent: SpanContext | undefined;
+}
+
+/** Minimal no-op span: only its creation and parent are under test. */
+function noopSpan(): Span {
+  const span = {
+    spanContext: () => ({ traceId: "", spanId: "", traceFlags: 0 }),
+    setAttribute: () => span,
+    setAttributes: () => span,
+    addEvent: () => span,
+    addLink: () => span,
+    addLinks: () => span,
+    setStatus: () => span,
+    updateName: () => span,
+    end: () => {},
+    isRecording: () => false,
+    recordException: () => {},
+  } as unknown as Span;
+  return span;
+}
+
+/**
+ * Registered ONCE for the whole file, not per test.
+ *
+ * The API's `ProxyTracer` caches its delegate the first time it resolves one,
+ * so re-registering a provider between tests leaves the proxy pointing at the
+ * first tracer — spans then land in a previous test's buffer and the test reads
+ * an empty one. One provider, one buffer, cleared per test.
+ */
+const captured: Captured[] = [];
+
+const capturingTracer = {
+  startSpan(name: string, _options?: unknown, context?: Context): Span {
+    captured.push({
+      name,
+      parent: context ? trace.getSpanContext(context) : undefined,
+    });
+    return noopSpan();
+  },
+  startActiveSpan: ((_n: string, ..._rest: unknown[]) => undefined) as never,
+} as unknown as Tracer;
+
+const capturingProvider: TracerProvider = { getTracer: () => capturingTracer };
+trace.setGlobalTracerProvider(capturingProvider);
+
+// The registration is global, but its blast radius is this module: Deno gives
+// each test file its own isolate, so another file still sees OTel's default
+// no-op tracer. Verified rather than assumed — a probe in a sibling file got
+// back the default `NonRecordingSpan` (an all-zero trace id) while this
+// provider was installed.
+//
+// Within this module it cannot be unregistered between tests: the API's
+// ProxyTracer caches its delegate on first resolution, so a second
+// `setGlobalTracerProvider` leaves spans landing in the first buffer. Hence one
+// provider and one buffer, cleared per test.
+
+
+/** Clear the buffer and return the span opened by the next tool call. */
+function reset(): void {
+  captured.length = 0;
+}
+
+function toolSpan(): Captured | undefined {
+  return captured.find((s) => s.name === "mcp.tool.call echo");
+}
+
+function buildApp(seen: { logLevel?: string }): McpApp {
+  const app = new McpApp({
+    name: "wiring-probe",
+    version: "1.0.0",
+    logger: () => {},
+  });
+
+  app.registerTool(
+    { name: "echo", description: "echo", inputSchema: { type: "object" } },
+    (_args, ctx) => {
+      seen.logLevel = ctx?.logLevel;
+      return "ok";
+    },
+  );
+
+  return app;
+}
+
+async function callOverHttp(
+  app: McpApp,
+  meta: Record<string, unknown>,
+): Promise<void> {
+  const listener = Deno.listen({ port: 0 });
+  const port = (listener.addr as Deno.NetAddr).port;
+  listener.close();
+  const http = await app.startHttp({ port, onListen: () => {} });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "echo",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "echo",
+          arguments: {},
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+            ...meta,
+          },
+        },
+      }),
+    });
+    await response.json();
+  } finally {
+    await http.shutdown();
+  }
+}
+
+Deno.test("wiring - a tool span is parented to the caller's traceparent", async () => {
+  reset();
+  await callOverHttp(buildApp({}), {
+    traceparent: TRACEPARENT,
+    tracestate: "vendor=abc",
+  });
+
+  const span = toolSpan();
+  assertExists(span, "the tool call should have opened a span");
+  assertExists(span.parent, "the span should have a remote parent");
+  assertEquals(span.parent.traceId, TRACE_ID);
+  assertEquals(span.parent.spanId, SPAN_ID);
+  assertEquals(span.parent.isRemote, true);
+  assertEquals(span.parent.traceState?.get("vendor"), "abc");
+});
+
+Deno.test("wiring - no traceparent leaves the span unparented", async () => {
+  reset();
+  await callOverHttp(buildApp({}), {});
+
+  const span = toolSpan();
+  assertExists(span);
+  assertEquals(span.parent, undefined);
+});
+
+Deno.test("wiring - a malformed traceparent degrades to an unparented span", async () => {
+  // The call must still succeed: losing the trace join is an observability
+  // gap, refusing the call would be an outage.
+  reset();
+  await callOverHttp(buildApp({}), { traceparent: "not-a-traceparent" });
+
+  const span = toolSpan();
+  assertExists(span, "the call must still run");
+  assertEquals(span.parent, undefined);
+});
+
+Deno.test("wiring - clientMeta reaches the handler in the right argument slot", async () => {
+  // `executeToolCall` takes clientMeta as its SIXTH positional argument. Passing
+  // it one position off would land it in `mrtr` and vanish without a type error
+  // at the call site. `logLevel` is the observable half of the same object, so
+  // seeing it in the handler proves the slot is right for `traceContext` too.
+  reset();
+  const seen: { logLevel?: string } = {};
+  await callOverHttp(buildApp(seen), {
+    "io.modelcontextprotocol/logLevel": "debug",
+    traceparent: TRACEPARENT,
+  });
+
+  assertEquals(seen.logLevel, "debug");
+});

--- a/packages/server/src/stdio-discover_test.ts
+++ b/packages/server/src/stdio-discover_test.ts
@@ -1,0 +1,194 @@
+/**
+ * `server/discover` over the SDK-routed transport (spec 2026-07-28, SEP-2575).
+ *
+ * The spec makes the RPC a MUST for every server and names stdio as a primary
+ * use — a client probes it for backward compatibility. Before this was wired,
+ * a stdio peer got `-32601`, so the probe reported "not a 2026 server" for a
+ * server that speaks 2026-07-28 over HTTP.
+ *
+ * These tests drive the same `Server` instance `start()` connects to stdio,
+ * over an in-memory transport instead: spawning a subprocess would need
+ * `--allow-run` in the test task and would only add coverage of
+ * `StdioServerTransport`, which is SDK code. The reach into the private field
+ * is deliberate — the alternative is widening the public API for a test.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { McpApp } from "./mcp-app.ts";
+
+const PROTOCOL_VERSION = "2026-07-28";
+const SERVER_INFO_KEY = "io.modelcontextprotocol/serverInfo";
+
+/** Speak raw JSON-RPC: the SDK client has no `server/discover` in its surface. */
+class Peer {
+  #transport: InMemoryTransport;
+  #pending = new Map<number, (msg: Record<string, unknown>) => void>();
+
+  constructor(transport: InMemoryTransport) {
+    this.#transport = transport;
+    this.#transport.onmessage = (message: JSONRPCMessage) => {
+      const msg = message as unknown as Record<string, unknown>;
+      const id = msg.id;
+      if (typeof id === "number") this.#pending.get(id)?.(msg);
+    };
+  }
+
+  request(id: number, method: string, params: Record<string, unknown> = {}) {
+    const settled = new Promise<Record<string, unknown>>((resolve) => {
+      this.#pending.set(id, resolve);
+    });
+    // deno-lint-ignore no-explicit-any
+    this.#transport.send({ jsonrpc: "2.0", id, method, params } as any);
+    return settled;
+  }
+
+  notify(method: string) {
+    // deno-lint-ignore no-explicit-any
+    return this.#transport.send({ jsonrpc: "2.0", method } as any);
+  }
+}
+
+async function connectedPeer(app: McpApp) {
+  const [clientTransport, serverTransport] = InMemoryTransport
+    .createLinkedPair();
+
+  const inner = (app as unknown as { mcpServer: McpServer }).mcpServer.server;
+  await inner.connect(serverTransport);
+
+  const peer = new Peer(clientTransport);
+  await clientTransport.start();
+
+  await peer.request(1, "initialize", {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: { name: "probe", version: "1.0.0" },
+  });
+  await peer.notify("notifications/initialized");
+
+  return { peer, close: () => inner.close() };
+}
+
+function buildApp(instructions?: string): McpApp {
+  const app = new McpApp({
+    name: "discover-probe",
+    version: "1.2.3",
+    logger: () => {},
+    ...(instructions ? { instructions } : {}),
+  });
+  app.registerTool(
+    { name: "noop", description: "noop", inputSchema: { type: "object" } },
+    () => "ok",
+  );
+  return app;
+}
+
+Deno.test("stdio - server/discover answers with the 2026-07-28 envelope", async () => {
+  const { peer, close } = await connectedPeer(buildApp());
+  try {
+    const response = await peer.request(2, "server/discover");
+    const result = response.result as Record<string, unknown>;
+
+    assertExists(result, "server/discover must not be MethodNotFound on stdio");
+    assertEquals(result.supportedVersions, [PROTOCOL_VERSION]);
+    assertEquals(result.serverInfo, {
+      name: "discover-probe",
+      version: "1.2.3",
+    });
+
+    // The method exists only in 2026-07-28, so its result carries that
+    // revision's envelope even though `initialize` negotiated an older one.
+    assertEquals(result.resultType, "complete");
+    assertEquals(result.cacheScope, "private");
+    assertEquals(result.ttlMs, 0);
+    assertEquals(
+      (result._meta as Record<string, unknown>)[SERVER_INFO_KEY],
+      { name: "discover-probe", version: "1.2.3" },
+    );
+  } finally {
+    await close();
+  }
+});
+
+Deno.test("stdio - server/discover carries instructions when configured", async () => {
+  const { peer, close } = await connectedPeer(buildApp("Use noop sparingly."));
+  try {
+    const response = await peer.request(2, "server/discover");
+    assertEquals(
+      (response.result as Record<string, unknown>).instructions,
+      "Use noop sparingly.",
+    );
+  } finally {
+    await close();
+  }
+});
+
+Deno.test("stdio - an unknown method is still MethodNotFound", async () => {
+  // The fallback handler catches every unrouted method, so the guard inside it
+  // is the only thing keeping `-32601` for everything that is not discover.
+  const { peer, close } = await connectedPeer(buildApp());
+  try {
+    const response = await peer.request(2, "server/undiscover");
+    const error = response.error as Record<string, unknown>;
+
+    assertExists(error);
+    assertEquals(error.code, -32601);
+    // Pinned because the message DID change with this handler. The SDK's own
+    // unrouted-method path answered a bare "Method not found"; an error raised
+    // from a handler travels as `McpError`, whose constructor prefixes
+    // "MCP error <code>: ". There is no way to raise the code from a handler
+    // without the prefix, so the string is what it is — pinned here so the next
+    // change to it is a decision rather than a surprise. The code, which is
+    // what a peer switches on, is unchanged.
+    assertEquals(error.message, "MCP error -32601: Method not found");
+  } finally {
+    await close();
+  }
+});
+
+Deno.test("stdio and HTTP report the same discover result", async () => {
+  // Two transports built the payload independently once; that is how
+  // `instructions` or a new capability ends up on one path only.
+  const app = buildApp("shared");
+  const listener = Deno.listen({ port: 0 });
+  const port = (listener.addr as Deno.NetAddr).port;
+  listener.close();
+  const http = await app.startHttp({ port, onListen: () => {} });
+
+  const { peer, close } = await connectedPeer(buildApp("shared"));
+  try {
+    const overHttp = await (await fetch(`http://localhost:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": PROTOCOL_VERSION,
+        "Mcp-Method": "server/discover",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 9,
+        method: "server/discover",
+        params: {
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {},
+          },
+        },
+      }),
+    })).json();
+
+    const overStdio = await peer.request(2, "server/discover");
+
+    // Round-trip the in-memory result through JSON, as a real stdio transport
+    // does. `buildServerCapabilities()` sets `resources: undefined` when none
+    // are registered; serialising drops the key on both paths, so comparing
+    // the live object against a parsed one would fail on an artefact of the
+    // test harness rather than on a difference between the transports.
+    assertEquals(JSON.parse(JSON.stringify(overStdio.result)), overHttp.result);
+  } finally {
+    await close();
+    await http.shutdown();
+  }
+});

--- a/packages/server/src/stdio-e2e_test.ts
+++ b/packages/server/src/stdio-e2e_test.ts
@@ -1,0 +1,127 @@
+/**
+ * The stdio transport, end to end, through a real subprocess.
+ *
+ * `stdio-discover_test.ts` drives the SDK `Server` directly over an in-memory
+ * transport, which is fast but reaches into a private field and never calls
+ * `start()`. Two independent reviews flagged the same gap: those tests stay
+ * green if `start()` connects the wrong instance, or stops installing handlers
+ * altogether. This one spawns `deno run` on a fixture server and talks JSON-RPC
+ * down its stdin, so nothing between `McpApp.start()` and the wire is mocked.
+ *
+ * One process for the whole file — spawning is the expensive part, and the
+ * transport is stateless, so the requests are independent anyway.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+
+const FIXTURE = new URL("./testdata/stdio-e2e-server.ts", import.meta.url)
+  .pathname;
+
+interface Response {
+  readonly id?: number;
+  readonly result?: Record<string, unknown>;
+  readonly error?: { code: number; message: string };
+}
+
+/**
+ * Send every request down one stdin, then read every response.
+ *
+ * Batching avoids interleaving reads with writes: the SDK answers out of order
+ * (its `initialize` reply arrived after a later response in practice), so the
+ * responses are matched by id rather than by position.
+ */
+async function exchange(
+  requests: ReadonlyArray<Record<string, unknown>>,
+): Promise<Map<number, Response>> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", "--no-check", FIXTURE],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "null",
+  });
+
+  const child = command.spawn();
+  const writer = child.stdin.getWriter();
+  const encoder = new TextEncoder();
+
+  for (const request of requests) {
+    await writer.write(encoder.encode(`${JSON.stringify(request)}\n`));
+  }
+  await writer.close();
+
+  const { stdout } = await child.output();
+
+  const byId = new Map<number, Response>();
+  for (const line of new TextDecoder().decode(stdout).split("\n")) {
+    if (line.trim().length === 0) continue;
+    const message = JSON.parse(line) as Response;
+    if (typeof message.id === "number") byId.set(message.id, message);
+  }
+  return byId;
+}
+
+function request(
+  id: number,
+  method: string,
+  params: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, method, params };
+}
+
+const HANDSHAKE = [
+  request(1, "initialize", {
+    protocolVersion: "2026-07-28",
+    capabilities: {},
+    clientInfo: { name: "e2e", version: "1.0.0" },
+  }),
+  { jsonrpc: "2.0", method: "notifications/initialized" },
+];
+
+Deno.test("stdio e2e - a spawned server answers server/discover", async () => {
+  const responses = await exchange([
+    ...HANDSHAKE,
+    request(2, "server/discover"),
+    request(3, "tools/list"),
+  ]);
+
+  const discover = responses.get(2);
+  assertExists(discover, "server/discover got no response at all");
+  assertEquals(
+    discover.error,
+    undefined,
+    `server/discover failed: ${JSON.stringify(discover.error)}`,
+  );
+
+  const result = discover.result;
+  assertExists(result);
+  assertEquals(result.supportedVersions, ["2026-07-28"]);
+  assertEquals(result.serverInfo, { name: "e2e-stdio", version: "9.9.9" });
+  assertEquals(result.instructions, "fixture server");
+  assertEquals(result.resultType, "complete");
+
+  // The rest of the server still works through the same process.
+  const tools = responses.get(3);
+  assertExists(tools?.result);
+  assertEquals(
+    (tools.result.tools as Array<{ name: string }>).map((t) => t.name),
+    ["echo"],
+  );
+});
+
+Deno.test("stdio e2e - an unknown method is MethodNotFound, not a crash", async () => {
+  const responses = await exchange([
+    ...HANDSHAKE,
+    request(2, "server/undiscover"),
+    // Proves the process survived the thrown McpError and keeps serving.
+    request(3, "tools/call", { name: "echo", arguments: { value: "alive" } }),
+  ]);
+
+  assertEquals(responses.get(2)?.error?.code, -32601);
+
+  const call = responses.get(3);
+  assertExists(call?.result, "the server stopped serving after the error");
+  assertEquals(
+    (call.result.content as Array<{ text: string }>)[0].text,
+    "alive",
+  );
+});

--- a/packages/server/src/testdata/stdio-e2e-server.ts
+++ b/packages/server/src/testdata/stdio-e2e-server.ts
@@ -1,0 +1,30 @@
+/**
+ * A real stdio server, started the way a consumer starts one.
+ *
+ * Spawned as a subprocess by `stdio-e2e_test.ts`. Kept as a fixture rather than
+ * written to a temp file at run time so the thing under test is readable and
+ * versioned: this is exactly the five lines from the README.
+ */
+
+import { McpApp } from "../mcp-app.ts";
+
+const app = new McpApp({
+  name: "e2e-stdio",
+  version: "9.9.9",
+  logger: () => {},
+  instructions: "fixture server",
+});
+
+app.registerTool(
+  {
+    name: "echo",
+    description: "Echo the input",
+    inputSchema: {
+      type: "object",
+      properties: { value: { type: "string" } },
+    },
+  },
+  (args) => args.value ?? "empty",
+);
+
+await app.start();

--- a/packages/server/src/validation/schema-validator.ts
+++ b/packages/server/src/validation/schema-validator.ts
@@ -8,7 +8,20 @@
  */
 
 // deno-lint-ignore-file no-explicit-any
-import AjvDefault from "ajv";
+// Draft 2020-12, not ajv's default export (draft-07). Spec 2026-07-28
+// (SEP-2106) allows any JSON Schema 2020-12 keyword in `inputSchema` /
+// `outputSchema`, and the draft-07 build treats the keywords added in 2020-12 —
+// `prefixItems`, `unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef` —
+// as unknown. Combined with `strict: false` that failure is silent: the schema
+// compiles, the constraint is never applied, and a violating payload validates
+// clean. A tool author's declared boundary has to actually hold.
+//
+// Spelled as the full `dist/` path, not `ajv/2020`: `build-node.sh` copies
+// import specifiers verbatim into the npm distribution, and ajv 8 ships no
+// `exports` map and no root-level `2020.js`, so `ajv/2020` resolves under
+// Deno's import map and then fails at runtime in Node with ERR_MODULE_NOT_FOUND.
+// This path resolves under both.
+import AjvDefault from "ajv/dist/2020.js";
 
 // Get the Ajv constructor (handles ESM/CJS differences)
 const Ajv = (AjvDefault as any).default ?? AjvDefault;

--- a/packages/server/src/validation/schema-validator_test.ts
+++ b/packages/server/src/validation/schema-validator_test.ts
@@ -336,3 +336,132 @@ Deno.test("SchemaValidator - uniqueItems and object-size bounds are reported too
   assertEquals(crowded.valid, false);
   assertEquals(crowded.errors[0].expected, "properties <= 2");
 });
+
+// ── JSON Schema 2020-12 (spec 2026-07-28, SEP-2106) ─────────────────────────
+//
+// These assert on the draft, not on a feature. Against ajv's default export —
+// draft-07 — every one of them passed as `valid: true`: the keyword was
+// unknown, `strict: false` swallowed it, and the constraint silently never ran.
+// A validator that accepts what it was told to reject is worse than none,
+// because callers stop checking themselves. These fail loudly if the import
+// ever falls back to the draft-07 build.
+
+Deno.test("SchemaValidator - 2020-12 prefixItems constrains tuple positions", () => {
+  const validator = new SchemaValidator();
+
+  validator.addSchema("tuple", {
+    type: "object",
+    properties: {
+      pair: {
+        type: "array",
+        prefixItems: [{ type: "string" }, { type: "number" }],
+      },
+    },
+  });
+
+  assertEquals(validator.validate("tuple", { pair: ["a", 1] }).valid, true);
+
+  const swapped = validator.validate("tuple", { pair: [1, "a"] });
+  assertEquals(swapped.valid, false);
+  assertEquals(swapped.errors[0].path, "/pair/0");
+  assertEquals(swapped.errors[0].expected, "string");
+});
+
+Deno.test("SchemaValidator - 2020-12 unevaluatedProperties seals an object", () => {
+  const validator = new SchemaValidator();
+
+  validator.addSchema("sealed", {
+    type: "object",
+    properties: { a: { type: "string" } },
+    unevaluatedProperties: false,
+  });
+
+  assertEquals(validator.validate("sealed", { a: "x" }).valid, true);
+  assertEquals(
+    validator.validate("sealed", { a: "x", smuggled: "in" }).valid,
+    false,
+  );
+});
+
+Deno.test("SchemaValidator - 2020-12 unevaluatedItems bounds an array", () => {
+  const validator = new SchemaValidator();
+
+  validator.addSchema("bounded_items", {
+    type: "object",
+    properties: {
+      only_two: {
+        type: "array",
+        prefixItems: [{ type: "string" }, { type: "string" }],
+        unevaluatedItems: false,
+      },
+    },
+  });
+
+  assertEquals(
+    validator.validate("bounded_items", { only_two: ["a", "b"] }).valid,
+    true,
+  );
+  assertEquals(
+    validator.validate("bounded_items", { only_two: ["a", "b", "c"] }).valid,
+    false,
+  );
+});
+
+Deno.test("SchemaValidator - the draft-07 keywords shared with 2020-12 still validate", () => {
+  // Scoped to the shared subset on purpose — this does NOT claim draft-07
+  // compatibility in general. `items` as a single subschema means the same
+  // thing in both drafts, and that is the spelling in use across this repo.
+  // The tuple form is the one that changed; see the test below.
+  const validator = new SchemaValidator();
+
+  validator.addSchema("legacy", {
+    type: "object",
+    properties: {
+      tags: { type: "array", items: { type: "string" }, minItems: 1 },
+      code: { type: "string", pattern: "^[a-z]+$" },
+    },
+    required: ["code"],
+    additionalProperties: false,
+  });
+
+  assertEquals(
+    validator.validate("legacy", { code: "abc", tags: ["x"] }).valid,
+    true,
+  );
+  assertEquals(validator.validate("legacy", { code: "ABC" }).valid, false);
+  assertEquals(validator.validate("legacy", { tags: ["x"] }).valid, false);
+  assertEquals(
+    validator.validate("legacy", { code: "abc", extra: 1 }).valid,
+    false,
+  );
+});
+
+Deno.test("SchemaValidator - a draft-07 tuple schema is rejected at registration", () => {
+  // The sharp edge of the 2020-12 move, pinned so nobody has to rediscover it
+  // from a bug report. `items: [...]` was the draft-07 tuple form; 2020-12
+  // replaced it with `prefixItems` and requires `items` to be a single
+  // subschema.
+  //
+  // The failure is louder than "the constraint stops applying": ajv rejects the
+  // schema at compile time, so `addSchema` throws and the tool never
+  // registers. That is the right failure — a tool whose declared boundary
+  // cannot be enforced should not come up pretending it can — but it is a
+  // breaking change for any consumer shipping a tuple, and it surfaces at
+  // startup rather than on the first call.
+  const validator = new SchemaValidator();
+
+  assertThrows(
+    () =>
+      validator.addSchema("legacy_tuple", {
+        type: "object",
+        properties: {
+          pair: {
+            type: "array",
+            items: [{ type: "string" }, { type: "number" }],
+          },
+        },
+      }),
+    Error,
+    "schema is invalid",
+  );
+});


### PR DESCRIPTION
Quatre trous trouvés en confrontant le code à la spec. Aucun n'était visible depuis une suite verte.

## 1. Exposition de credentials — SEP-2352 ⚠️

`tokens()` rendait les credentials stockés à qui les demandait. Or `auth()` du SDK découvre le serveur d'autorisation depuis la métadonnée publiée par le **serveur MCP lui-même**, puis passe ces tokens à `refreshAuthorization(authorizationServerUrl, …)`.

Un serveur MCP qui change d'AS — ou qu'on amène à en annoncer un autre — **recevait donc un refresh_token émis par le précédent**. Un client ne doit pas laisser le serveur de ressources choisir qui voit ses secrets.

La liaison est enregistrée depuis `saveDiscoveryState()`, que `auth()` appelle après la découverte et avant de demander les tokens. Elle porte sur l'**URL découverte**, pas sur `metadata.issuer` : ce champ est publié par l'AS sur lui-même, et le SDK 1.29 en valide la forme sans le confronter à l'URL d'origine — s'y lier laisserait le serveur d'un attaquant déverrouiller les credentials d'un autre en usurpant son nom.

**Rupture** : les credentials déjà stockés n'ont pas d'issuer enregistré, ils sont écartés une fois et une ré-autorisation est nécessaire.

## 2. `server/discover` manquait sur stdio

La spec en fait un MUST et désigne stdio comme usage principal — un client s'en sert comme sonde de compatibilité. Seul le chemin HTTP l'implémentait, donc un pair stdio recevait `-32601`, précisément dans le cas où la sonde existe : le handshake stdio du SDK négocie `2025-11-25`, et `server/discover` est le seul moyen d'apprendre que ce serveur parle aussi `2026-07-28` en HTTP.

## 3. La validation d'arguments tournait sur draft-07

Le validateur importait l'entrée par défaut d'ajv, alors que la spec impose 2020-12 comme dialecte par défaut. Les mots-clés ajoutés en 2020-12 étaient inconnus et, avec `strict: false`, **l'échec était silencieux** : un outil déclarant `prefixItems: [{type:"string"}, {type:"number"}]` acceptait `[42, "nope"]`.

Le specifier est `ajv/dist/2020.js` et non `ajv/2020` : `build-node.sh` copie les imports verbatim et ajv 8 n'a ni `exports` ni `2020.js` racine — le paquet npm aurait cassé au premier `import`.

## 4. Aucune propagation de trace W3C

`traceparent`/`tracestate` n'étaient jamais lus : chaque span d'appel d'outil démarrait détaché de la trace de l'appelant. Les deux sont désormais lus dans `params._meta` et validés contre la grammaire W3C avant d'être réémis vers l'aval. `baggage` reste délibérément ignoré — liste non bornée contrôlée par l'appelant, que ce serveur ne pourrait qu'exporter vers le backend de traces sans savoir s'il s'y trouve un secret.

## Ruptures, documentées au CHANGELOG

| Rupture | Portée |
|---|---|
| Credentials stockés écartés une fois (SEP-2352) | ré-autorisation au prochain démarrage |
| Schéma tuple draft-07 (`items: [...]`) rejeté à l'enregistrement | aucun consommateur du monorepo ni des 11 serveurs MCP ne l'utilise |
| Message des méthodes inconnues préfixé `MCP error -32601: ` | le code est inchangé ; seul un pair matchant sur le texte est affecté |

## Vérification

**755 tests, 0 échec.** Cinq passes de review Codex, dont chacune a rattrapé quelque chose :

1. la rupture du build npm (`ajv/2020` irrésoluble sous Node) ;
2. trois défauts de conformité W3C du parseur, et le `baggage` exporté vers les traces ;
3. deux commentaires qui affirmaient faux — dont un tranché par une sonde plutôt qu'à l'autorité ;
4. **deux contournements complets de la protection SEP-2352** : la liaison sur `metadata.issuer` (usurpable) et le report du refresh_token lors d'un code exchange ;
5. une fuite de secrets d'URL dans les logs.

Le transport stdio est aussi couvert de bout en bout par un vrai subprocess, vérifié par mutation : désactiver le correctif fait échouer le test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)